### PR TITLE
perf: streamline SortedHashSet add

### DIFF
--- a/onyx-database/src/main/kotlin/com/onyx/lang/SortedHashSet.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/lang/SortedHashSet.kt
@@ -1,19 +1,17 @@
 package com.onyx.lang
 
-import kotlin.math.abs
-
-
 /**
  * Array List that accepts a comparator.  Why this is not part of the JVM who knows...
  */
 class SortedHashSet<T>(private val comparator:Comparator<T>) : SortedList<T>(comparator) {
 
     override fun add(element: T): Boolean {
-        if(this.contains(element))
+        var index = this.binarySearch { comparator.compare(it, element) }
+        if(index >= 0) {
             return false
-        var insertionIndex = abs(this.binarySearch { comparator.compare(it, element) }) -1
-        if(insertionIndex < 0) { insertionIndex = 0 }
-        super.add(insertionIndex, element)
+        }
+        index = -(index + 1)
+        super.add(index, element)
         return true
     }
 }


### PR DESCRIPTION
## Summary
- avoid redundant contains check when inserting into SortedHashSet

## Testing
- `./gradlew test -Psigning.secretKey='' -Psigning.password='' -PossrhUsername='' -PossrhPassword='' -Pkotlin.jvm.target=1.8 -Pkotlin.compiler.jvmTarget=1.8` *(fails: Inconsistent JVM-target compatibility detected for tasks 'compileJava' (1.8) and 'compileKotlin' (21))*

------
https://chatgpt.com/codex/tasks/task_e_688e5496c5108327a2f3db08d6574bbf