### PR TITLE
Cache read/write locks in read-write lock wrapper

### DIFF
--- a/onyx-database/src/main/kotlin/com/onyx/lang/concurrent/impl/ClosureReadWriteCompatLock.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/lang/concurrent/impl/ClosureReadWriteCompatLock.kt
@@ -6,31 +6,33 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 class ClosureReadWriteCompatLock : ClosureReadWriteLock {
 
     private val reentrantReadWriteLock = ReentrantReadWriteLock()
+    private val readLock = reentrantReadWriteLock.readLock()
+    private val writeLock = reentrantReadWriteLock.writeLock()
 
     override fun <T> readLock(consumer: () -> T): T {
-        reentrantReadWriteLock.readLock().lock()
+        readLock.lock()
         return try {
             consumer.invoke()
         } finally {
-            reentrantReadWriteLock.readLock().unlock()
+            readLock.unlock()
         }
     }
 
     override fun <T> optimisticReadLock(consumer: () -> T): T {
-        reentrantReadWriteLock.readLock().lock()
+        readLock.lock()
         return try {
             consumer.invoke()
         } finally {
-            reentrantReadWriteLock.readLock().unlock()
+            readLock.unlock()
         }
     }
 
     override fun <T> writeLock(consumer: () -> T): T {
-        reentrantReadWriteLock.writeLock().lock()
+        writeLock.lock()
         return try {
             consumer.invoke()
         } finally {
-            reentrantReadWriteLock.writeLock().unlock()
+            writeLock.unlock()
         }
     }
 }


### PR DESCRIPTION
## Summary
- cache read/write lock instances in `ClosureReadWriteCompatLock` to eliminate repeated lookups

## Testing
- `./gradlew test` *(fails: null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_688e605ddf2083279288b6f70b0733f5