### PR TITLE
Add unit tests for SortedHashSet

### DIFF
--- a/onyx-database-tests/src/test/kotlin/lang/SortedHashSetTest.kt
+++ b/onyx-database-tests/src/test/kotlin/lang/SortedHashSetTest.kt
@@ -1,0 +1,44 @@
+package lang
+
+import com.onyx.lang.SortedHashSet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SortedHashSetTest {
+
+    @Test
+    fun `adding elements maintains sort order`() {
+        val set = SortedHashSet<Int>(Comparator.naturalOrder())
+        set.add(5)
+        set.add(1)
+        set.add(3)
+        set.add(2)
+        set.add(4)
+        assertEquals(listOf(1, 2, 3, 4, 5), set)
+    }
+
+    @Test
+    fun `adding duplicate elements returns false and does not change size`() {
+        val set = SortedHashSet<Int>(Comparator.naturalOrder())
+        val first = set.add(1)
+        val second = set.add(1)
+        assertTrue(first)
+        assertFalse(second)
+        assertEquals(1, set.size)
+    }
+
+    @Test
+    fun `comparator determines uniqueness`() {
+        val set = SortedHashSet<String>(Comparator { a, b -> a.length.compareTo(b.length) })
+        val first = set.add("a")
+        val second = set.add("b")
+        val third = set.add("ccc")
+        assertTrue(first)
+        assertFalse(second)
+        assertTrue(third)
+        assertEquals(listOf("a", "ccc"), set)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests covering SortedHashSet ordering, duplicate handling, and comparator-based uniqueness

## Testing
- `./gradlew :onyx-database-tests:test` *(fails: Could not resolve io.ktor:ktor-bom:3.0.3 … java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_688e57aaeb608327aea4b4ce070b77bc