### PR TITLE
Use shared Metal backend instance

### DIFF
--- a/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/ComputeBackendFactory.kt
+++ b/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/ComputeBackendFactory.kt
@@ -19,7 +19,7 @@ object ComputeBackendFactory {
         return when {
             isMetalAvailable() -> {
                 try {
-                    MetalComputeBackend()
+                    metalCompute
                 } catch (e: Exception) {
                     println("Metal backend failed to initialize: ${e.message}")
                     println("Falling back to CPU backend")
@@ -63,7 +63,7 @@ object ComputeBackendFactory {
             throw RuntimeException("Metal backend is not available on this system")
         }
         return try {
-            MetalComputeBackend()
+            metalCompute
         } catch (e: Exception) {
             println("Failed to initialize Metal backend: ${e.message}")
             println("Falling back to CPU backend")

--- a/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/MetalComputeBackend.kt
+++ b/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/MetalComputeBackend.kt
@@ -458,4 +458,4 @@ class MetalComputeBackend : CPUComputeBackend() {
     }
 }
 
-val metalCompute = MetalComputeBackend()
+val metalCompute by lazy { MetalComputeBackend() }


### PR DESCRIPTION
## Summary
- Avoid repeated GPU copies by reusing a singleton `MetalComputeBackend`
- Lazily initialize the global Metal backend to prevent leaks

## Testing
- `./gradlew :onyx-ai:test` *(fails: Failed to apply plugin 'com.onyxdevtools.java-conventions' - null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_689f56845d748327a472f7d6f2ff99d3