### PR TITLE
Avoid UnsatisfiedLinkError for GPU transpose-scale multiply

### DIFF
--- a/onyx-ai/src/main/native/metal/OnyxMetal.mm
+++ b/onyx-ai/src/main/native/metal/OnyxMetal.mm
@@ -676,6 +676,24 @@ Java_com_onyxdevtools_ai_compute_MetalComputeBackend_gpuMatrixMultiply(
     }
 }
 
+// GPU matrix multiplication where the right-hand matrix is logically
+// transposed and the result is scaled by the provided factor. This
+// functionality is currently not implemented in the Metal backend, so we
+// return JNI_FALSE to trigger the CPU fallback in Kotlin code. Having this
+// stub prevents UnsatisfiedLinkError crashes when the method is invoked.
+JNIEXPORT jboolean JNICALL
+Java_com_onyxdevtools_ai_compute_MetalComputeBackend_gpuMatrixMultiplyTransposeScale(
+    JNIEnv* env, jclass clazz, jlong contextHandle,
+    jlong bufferA, jint rowsA, jint colsA,
+    jlong bufferB, jint rowsB, jint colsB,
+    jfloat scale,
+    jlong bufferResult
+) {
+    @autoreleasepool {
+        return JNI_FALSE; // Not implemented, fall back to CPU
+    }
+}
+
 // GPU element-wise operations
 JNIEXPORT jboolean JNICALL
 Java_com_onyxdevtools_ai_compute_MetalComputeBackend_gpuElementWiseOperation(


### PR DESCRIPTION
## Summary
- Add stub `gpuMatrixMultiplyTransposeScale` native implementation to prevent crashes when invoked

## Testing
- `./gradlew :onyx-ai:test` *(fails: Failed to apply plugin 'com.onyxdevtools.java-conventions'. null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_689f6a7752848327944f97ae4cae0f21