### PR TITLE
Dispose CPU fallback tensors in Metal transpose-scale multiply

### DIFF
--- a/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/MetalComputeBackend.kt
+++ b/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/MetalComputeBackend.kt
@@ -328,7 +328,10 @@ class MetalComputeBackend : CPUComputeBackend() {
                 releaseTempBuffers(bufferA, bufferB, bufferResult)
                 val cpuTransposed = super.transpose(b)
                 val cpuResult = super.matrixMultiply(a, cpuTransposed)
-                return super.scalarMultiply(cpuResult, scale)
+                val cpuScaled = super.scalarMultiply(cpuResult, scale)
+                cpuTransposed.dispose()
+                cpuResult.dispose()
+                return cpuScaled
             }
 
             val resultData = copyFromGPU(metalContext, bufferResult, resultSize)
@@ -344,7 +347,10 @@ class MetalComputeBackend : CPUComputeBackend() {
             releaseTempBuffers(bufferA, bufferB, bufferResult)
             val cpuTransposed = super.transpose(b)
             val cpuResult = super.matrixMultiply(a, cpuTransposed)
-            super.scalarMultiply(cpuResult, scale)
+            val cpuScaled = super.scalarMultiply(cpuResult, scale)
+            cpuTransposed.dispose()
+            cpuResult.dispose()
+            cpuScaled
         }
     }
 


### PR DESCRIPTION
## Summary
- Dispose intermediate CPU tensors in `matrixMultiplyTransposeScale` fallback to avoid direct buffer leaks

## Testing
- `./gradlew :onyx-ai:test` *(fails: Failed to apply plugin 'com.onyxdevtools.java-conventions'. null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_689f6f82ebe483279b6df5e5a7a1cab5