### PR TITLE
Avoid eager CPU sync in Metal ops

### DIFF
--- a/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/MetalComputeBackend.kt
+++ b/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/MetalComputeBackend.kt
@@ -382,12 +382,8 @@ class MetalComputeBackend : CPUComputeBackend() {
                 releaseTempBuffers(inputBuffer, outputBuffer)
                 return super.transpose(tensor)
             }
-            val resultData = copyFromGPU(metalContext, outputBuffer, rows * cols)
             val buf = Tensor.allocateDirectBuffer(rows * cols)
-            for (i in 0 until rows * cols) {
-                buf.put(i, resultData[i])
-            }
-            val result = MetalTensor(buf, cols, rows, this, outputBuffer, true)
+            val result = MetalTensor(buf, cols, rows, this, outputBuffer, true, false)
             synchronized(bufferLock) { gpuBuffers.remove(outputBuffer) }
             releaseTempBuffers(inputBuffer)
             result
@@ -440,12 +436,8 @@ class MetalComputeBackend : CPUComputeBackend() {
                 releaseTempBuffers(bufferA, bufferB, bufferResult)
                 null
             } else {
-                val resultData = copyFromGPU(metalContext, bufferResult, rows * cols)
                 val buf = Tensor.allocateDirectBuffer(rows * cols)
-                for (i in 0 until rows * cols) {
-                    buf.put(i, resultData[i])
-                }
-                val result = MetalTensor(buf, rows, cols, this, bufferResult, true)
+                val result = MetalTensor(buf, rows, cols, this, bufferResult, true, false)
                 synchronized(bufferLock) { gpuBuffers.remove(bufferResult) }
                 releaseTempBuffers(bufferA, bufferB)
                 result


### PR DESCRIPTION
## Summary
- avoid CPU round trips for Metal element-wise and transpose operations
- lazily sync MetalTensor CPU buffers only when accessed

## Testing
- `./gradlew :onyx-ai:test` *(fails: Failed to apply plugin 'com.onyxdevtools.java-conventions': null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_689f706ed21883279e11100050fd28fc