### PR TITLE
Avoid CPU copy after Metal matrix multiply

### DIFF
--- a/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/MetalComputeBackend.kt
+++ b/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/MetalComputeBackend.kt
@@ -277,12 +277,8 @@ class MetalComputeBackend : CPUComputeBackend() {
                 return super.matrixMultiply(a, b)
             }
 
-            val resultData = copyFromGPU(metalContext, bufferResult, resultSize)
             val buf = Tensor.allocateDirectBuffer(resultSize)
-            for (i in 0 until resultSize) {
-                buf.put(i, resultData[i])
-            }
-            val result = MetalTensor(buf, rowsA, colsB, this, bufferResult, true)
+            val result = MetalTensor(buf, rowsA, colsB, this, bufferResult, true, false)
             synchronized(bufferLock) { gpuBuffers.remove(bufferResult) }
             releaseTempBuffers(bufferA, bufferB)
             result
@@ -334,12 +330,8 @@ class MetalComputeBackend : CPUComputeBackend() {
                 return cpuScaled
             }
 
-            val resultData = copyFromGPU(metalContext, bufferResult, resultSize)
             val buf = Tensor.allocateDirectBuffer(resultSize)
-            for (i in 0 until resultSize) {
-                buf.put(i, resultData[i])
-            }
-            val result = MetalTensor(buf, rowsA, rowsB, this, bufferResult, true)
+            val result = MetalTensor(buf, rowsA, rowsB, this, bufferResult, true, false)
             synchronized(bufferLock) { gpuBuffers.remove(bufferResult) }
             releaseTempBuffers(bufferA, bufferB)
             result


### PR DESCRIPTION
## Summary
- Avoid copying GPU results back to CPU for Metal matrix multiplication
- Defer CPU data retrieval until needed by marking buffer invalid

## Testing
- `./gradlew :onyx-ai:test -Psigning.password=dummy -Psigning.secretKey=ZHVtbXk= -PossrhUsername=dummy -PossrhPassword=dummy` *(fails: 90 tests completed, 12 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689f7e16b14483279883bb0e05806d18