### PR TITLE
Dispose intermediate tensors to prevent GPU memory leaks

### DIFF
--- a/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/ComputeContext.kt
+++ b/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/compute/ComputeContext.kt
@@ -60,7 +60,9 @@ class DefaultComputeContext : ComputeContext {
     override fun copyFromBackend(tensor: Tensor): Tensor = tensor
     
     override fun releaseMatrix(tensor: Tensor) {
-        // No-op for CPU matrices
+        // Ensure any underlying resources (e.g. GPU buffers) are released.
+        // For heap-backed tensors this is effectively a no-op.
+        tensor.dispose()
     }
     
     override fun getMemoryInfo(): ComputeMemoryInfo {


### PR DESCRIPTION
## Summary
- Ensure DefaultComputeContext releases underlying tensor resources
- Explicitly dispose temporary tensors in DenseLayer forward pass
- Release intermediate tensors in DenseLayer training steps to curb GPU memory buildup

## Testing
- `./gradlew :onyx-ai:test` *(fails: Failed to apply plugin 'com.onyxdevtools.java-conventions'. null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_689f7eea23f8832782dae296593a3eb9