### PR TITLE
Avoid double release of MetalTensor GPU buffers

### DIFF
--- a/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/Tensor.kt
+++ b/onyx-ai/src/main/kotlin/com/onyxdevtools/ai/Tensor.kt
@@ -285,10 +285,15 @@ class MetalTensor(
 
     override fun dispose() {
         if (ownsGpuBuffer && gpuBufferHandle != 0L && metal != null) {
-            try { MetalComputeBackend.releaseGPUBuffer(metal.metalContext, gpuBufferHandle) } catch (_: Throwable) {}
-            cleanable?.clean()
-            cleanable = null
+            if (cleanable != null) {
+                // Cleaner will release the GPU buffer exactly once
+                cleanable!!.clean()
+                cleanable = null
+            } else {
+                try { MetalComputeBackend.releaseGPUBuffer(metal.metalContext, gpuBufferHandle) } catch (_: Throwable) {}
+            }
             gpuBufferHandle = 0L
+            ownsGpuBuffer = false
         }
     }
 }


### PR DESCRIPTION
## Summary
- Ensure MetalTensor.dispose uses Cleaner or direct release but not both, preventing double-free and leaks

## Testing
- `./gradlew :onyx-ai:test` *(fails: Failed to apply plugin 'com.onyxdevtools.java-conventions'. null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_689f898146908327a4471f9d9a7dc1d3