### PR TITLE
Add test for skiplist iteration after full deletion

### DIFF
--- a/onyx-database-tests/src/test/kotlin/database/list/DeleteAllThenListTest.kt
+++ b/onyx-database-tests/src/test/kotlin/database/list/DeleteAllThenListTest.kt
@@ -1,0 +1,47 @@
+package database.list
+
+import com.onyx.persistence.IManagedEntity
+import com.onyx.persistence.query.from
+import database.base.DatabaseBaseTest
+import entities.AllAttributeForFetch
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.reflect.KClass
+import kotlin.test.assertEquals
+
+/**
+ * Verify that deleting all entities leaves the skiplist in a valid state
+ * and iterating over a list query on the emptied set does not throw.
+ */
+@RunWith(Parameterized::class)
+class DeleteAllThenListTest(override var factoryClass: KClass<*>) : DatabaseBaseTest(factoryClass) {
+
+    @After
+    fun cleanup() {
+        manager.from(AllAttributeForFetch::class).delete()
+    }
+
+    @Test
+    fun testListAfterDeletingAll() {
+        // insert some data
+        for (i in 0 until 10) {
+            val entity = AllAttributeForFetch()
+            entity.id = "ID" + i
+            entity.stringValue = "value" + i
+            manager.saveEntity<IManagedEntity>(entity)
+        }
+
+        // remove everything
+        manager.from(AllAttributeForFetch::class).delete()
+
+        // executing a list query and iterating the results should be safe
+        val results = manager.from(AllAttributeForFetch::class).list<AllAttributeForFetch>()
+        var count = 0
+        for (entity in results) {
+            count++
+        }
+        assertEquals(0, count, "All entities should have been removed")
+    }
+}


### PR DESCRIPTION
## Summary
- add DeleteAllThenListTest to ensure skiplist iteration after removing all nodes works without throwing

## Testing
- `../gradlew test --tests "database.list.DeleteAllThenListTest"` *(fails: null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_68bf980f700c8327915e0a65a73a9f89