### PR TITLE
Skip sentinel keys during skip-list search

### DIFF
--- a/onyx-database-tests/src/test/kotlin/database/list/NullIndexRangeTest.kt
+++ b/onyx-database-tests/src/test/kotlin/database/list/NullIndexRangeTest.kt
@@ -1,0 +1,29 @@
+package database.list
+
+import com.onyx.persistence.query.gt
+import database.base.DatabaseBaseTest
+import entities.NullIndexEntity
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.reflect.KClass
+import kotlin.test.assertEquals
+
+@RunWith(Parameterized::class)
+class NullIndexRangeTest(override var factoryClass: KClass<*>) : DatabaseBaseTest(factoryClass) {
+
+    @Test
+    fun rangeQuerySkipsNullIndexes() {
+        manager.saveEntity(NullIndexEntity().apply { id = "1"; longIndex = null })
+        manager.saveEntity(NullIndexEntity().apply { id = "2"; longIndex = 5L })
+        manager.saveEntity(NullIndexEntity().apply { id = "3"; longIndex = 10L })
+
+        val results = manager.from<NullIndexEntity>()
+            .where("longIndex" gt 6L)
+            .list<NullIndexEntity>()
+
+        assertEquals(1, results.size)
+        assertEquals(10L, results[0].longIndex)
+    }
+}
+

--- a/onyx-database-tests/src/test/kotlin/database/list/NullIndexRangeTest.kt
+++ b/onyx-database-tests/src/test/kotlin/database/list/NullIndexRangeTest.kt
@@ -1,8 +1,11 @@
 package database.list
 
+import com.onyx.persistence.query.from
 import com.onyx.persistence.query.gt
+import com.onyx.persistence.query.isNull
 import database.base.DatabaseBaseTest
 import entities.NullIndexEntity
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -11,6 +14,11 @@ import kotlin.test.assertEquals
 
 @RunWith(Parameterized::class)
 class NullIndexRangeTest(override var factoryClass: KClass<*>) : DatabaseBaseTest(factoryClass) {
+
+    @Before
+    fun before() {
+        manager.from<NullIndexEntity>().delete()
+    }
 
     @Test
     fun rangeQuerySkipsNullIndexes() {
@@ -24,6 +32,19 @@ class NullIndexRangeTest(override var factoryClass: KClass<*>) : DatabaseBaseTes
 
         assertEquals(1, results.size)
         assertEquals(10L, results[0].longIndex)
+    }
+
+    @Test
+    fun testIndexIsNull() {
+        manager.saveEntity(NullIndexEntity().apply { id = "1"; longIndex = null })
+        manager.saveEntity(NullIndexEntity().apply { id = "2"; longIndex = 5L })
+        manager.saveEntity(NullIndexEntity().apply { id = "3"; longIndex = 10L })
+
+        val results = manager.from<NullIndexEntity>()
+            .where("longIndex".isNull())
+            .list<NullIndexEntity>()
+
+        assertEquals(1, results.size)
     }
 }
 

--- a/onyx-database-tests/src/test/kotlin/diskmap/NullKeyTest.kt
+++ b/onyx-database-tests/src/test/kotlin/diskmap/NullKeyTest.kt
@@ -1,11 +1,10 @@
 package diskmap
 
 import com.onyx.diskmap.factory.impl.DefaultDiskMapFactory
-import com.onyx.diskmap.impl.DiskSkipListMap
 import database.base.DatabaseBaseTest
 import org.junit.BeforeClass
 import org.junit.Test
-import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class NullKeyTest {
 
@@ -21,24 +20,10 @@ class NullKeyTest {
     }
 
     @Test
-    fun putAndGetNullKey() {
+    fun putNullKeyThrows() {
         val store = DefaultDiskMapFactory(TEST_DATABASE)
         val map: MutableMap<String?, String> = store.getHashMap(String::class.java, "nullKeyMap")
-        map[null] = "nil"
-        assertEquals("nil", map[null])
-        store.close()
-    }
-
-    @Test
-    fun aboveSkipsNullKey() {
-        val store = DefaultDiskMapFactory(TEST_DATABASE)
-        val map: MutableMap<String?, String> = store.getHashMap(String::class.java, "rangeNullKeyMap")
-        map[null] = "nil"
-        map["b"] = "bee"
-        val skipMap = map as DiskSkipListMap<String?, String>
-        val results = skipMap.above("a", false).map { skipMap.getWithRecID(it) }
-        assertEquals(listOf("bee"), results)
+        assertFailsWith<NullPointerException> { map[null] = "nil" }
         store.close()
     }
 }
-

--- a/onyx-database-tests/src/test/kotlin/diskmap/NullKeyTest.kt
+++ b/onyx-database-tests/src/test/kotlin/diskmap/NullKeyTest.kt
@@ -1,0 +1,44 @@
+package diskmap
+
+import com.onyx.diskmap.factory.impl.DefaultDiskMapFactory
+import com.onyx.diskmap.impl.DiskSkipListMap
+import database.base.DatabaseBaseTest
+import org.junit.BeforeClass
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class NullKeyTest {
+
+    companion object {
+        private const val TEST_DATABASE = "C:/Sandbox/Onyx/Tests/nullKeyTest.db"
+
+        @BeforeClass
+        @JvmStatic
+        fun beforeClass() {
+            DatabaseBaseTest.deleteDatabase(TEST_DATABASE)
+            DatabaseBaseTest.deleteDatabase("$TEST_DATABASE.idx")
+        }
+    }
+
+    @Test
+    fun putAndGetNullKey() {
+        val store = DefaultDiskMapFactory(TEST_DATABASE)
+        val map: MutableMap<String?, String> = store.getHashMap(String::class.java, "nullKeyMap")
+        map[null] = "nil"
+        assertEquals("nil", map[null])
+        store.close()
+    }
+
+    @Test
+    fun aboveSkipsNullKey() {
+        val store = DefaultDiskMapFactory(TEST_DATABASE)
+        val map: MutableMap<String?, String> = store.getHashMap(String::class.java, "rangeNullKeyMap")
+        map[null] = "nil"
+        map["b"] = "bee"
+        val skipMap = map as DiskSkipListMap<String?, String>
+        val results = skipMap.above("a", false).map { skipMap.getWithRecID(it) }
+        assertEquals(listOf("bee"), results)
+        store.close()
+    }
+}
+

--- a/onyx-database-tests/src/test/kotlin/diskmap/RangeTraversalTest.kt
+++ b/onyx-database-tests/src/test/kotlin/diskmap/RangeTraversalTest.kt
@@ -1,0 +1,42 @@
+package diskmap
+
+import com.onyx.diskmap.factory.impl.DefaultDiskMapFactory
+import com.onyx.diskmap.impl.DiskSkipListMap
+import database.base.DatabaseBaseTest
+import org.junit.BeforeClass
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class RangeTraversalTest {
+    companion object {
+        private const val TEST_DATABASE = "C:/Sandbox/Onyx/Tests/rangeTraversal.db"
+
+        @BeforeClass
+        @JvmStatic
+        fun beforeClass() {
+            DatabaseBaseTest.deleteDatabase(TEST_DATABASE)
+            DatabaseBaseTest.deleteDatabase("$TEST_DATABASE.idx")
+        }
+    }
+
+    @Test
+    fun aboveBelowBetweenReachBottom() {
+        val store = DefaultDiskMapFactory(TEST_DATABASE)
+        val map = store.getHashMap(Int::class.java, "range") as DiskSkipListMap<Int, String>
+
+        for (i in 0 until 100) {
+            map.put(i, "v" + i)
+        }
+
+        val aboveVals = map.above(90, true).mapNotNull { map.getWithRecID(it) }
+        assertEquals((90..99).map { "v$it" }.toSet(), aboveVals.toSet())
+
+        val belowVals = map.below(9, true).mapNotNull { map.getWithRecID(it) }
+        assertEquals((0..9).map { "v$it" }.toSet(), belowVals.toSet())
+
+        val betweenVals = map.between(40, true, 44, true).mapNotNull { map.getWithRecID(it) }
+        assertEquals((40..44).map { "v$it" }.toSet(), betweenVals.toSet())
+
+        store.close()
+    }
+}

--- a/onyx-database/src/main/kotlin/com/onyx/diskmap/data/SkipNode.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/diskmap/data/SkipNode.kt
@@ -56,7 +56,7 @@ data class SkipNode(
 
     @Suppress("UNCHECKED_CAST")
     fun <T> getKey(records: Store, storedInNode: Boolean, type: Class<*>): T {
-        if (key == 0L) return null as T
+        if (key == 0L && record == 0L && left == 0L) return null as T
         if (keyValue != null) return keyValue as T
 
         if (storedInNode) {

--- a/onyx-database/src/main/kotlin/com/onyx/diskmap/data/SkipNode.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/diskmap/data/SkipNode.kt
@@ -56,6 +56,7 @@ data class SkipNode(
 
     @Suppress("UNCHECKED_CAST")
     fun <T> getKey(records: Store, storedInNode: Boolean, type: Class<*>): T {
+        if (key == 0L) return null as T
         if (keyValue != null) return keyValue as T
 
         if (storedInNode) {

--- a/onyx-database/src/main/kotlin/com/onyx/diskmap/impl/base/skiplist/AbstractSkipList.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/diskmap/impl/base/skiplist/AbstractSkipList.kt
@@ -344,14 +344,16 @@ abstract class AbstractSkipList<K, V>(
         var found = false
         moveDownLoop@ while (true) {
             moveRightLoop@ while (current.right > 0L && !found) {
-                val next: SkipNode = findNodeAtPosition(current.right) ?: break@moveRightLoop
-                val nextKeyAny = next.getKey<Any?>(records, storeKeyWithinNode, keyType)
-                if (nextKeyAny == null) {
+                val next: SkipNode = findNodeAtPosition(current.right)!!
+
+                // Skip sentinel nodes that have no associated key
+                if (next.key == 0L) {
                     current = next
                     continue@moveRightLoop
                 }
+
                 @Suppress("UNCHECKED_CAST")
-                val nextKey = nextKeyAny as K
+                val nextKey = next.getKey<Any?>(records, storeKeyWithinNode, keyType) as K
 
                 current = when {
                     isEqual(key, nextKey) -> {
@@ -365,17 +367,10 @@ abstract class AbstractSkipList<K, V>(
             }
 
             if (current.down > 0L) {
-                current = findNodeAtPosition(current.down) ?: break@moveDownLoop
+                current = findNodeAtPosition(current.down)!!
             } else {
                 break@moveDownLoop
             }
-        }
-
-        // ensure we always return a node from the bottom level even if the loop
-        // exited early due to a missing child pointer
-        while (current.down > 0L) {
-            val below = findNodeAtPosition(current.down) ?: break
-            current = below
         }
 
         return current

--- a/onyx-database/src/main/kotlin/com/onyx/diskmap/impl/base/skiplist/AbstractSkipList.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/diskmap/impl/base/skiplist/AbstractSkipList.kt
@@ -371,6 +371,13 @@ abstract class AbstractSkipList<K, V>(
             }
         }
 
+        // ensure we always return a node from the bottom level even if the loop
+        // exited early due to a missing child pointer
+        while (current.down > 0L) {
+            val below = findNodeAtPosition(current.down) ?: break
+            current = below
+        }
+
         return current
     }
 

--- a/onyx-database/src/main/kotlin/com/onyx/diskmap/impl/base/skiplist/AbstractSkipList.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/diskmap/impl/base/skiplist/AbstractSkipList.kt
@@ -345,13 +345,13 @@ abstract class AbstractSkipList<K, V>(
         moveDownLoop@ while (true) {
             moveRightLoop@ while (current.right > 0L && !found) {
                 val next: SkipNode = findNodeAtPosition(current.right) ?: break@moveRightLoop
-                @Suppress("UNCHECKED_CAST")
-                val nextKey = next.getKey<Any?>(records, storeKeyWithinNode, keyType) as K?
-
-                if (nextKey == null) {
+                val nextKeyAny = next.getKey<Any?>(records, storeKeyWithinNode, keyType)
+                if (nextKeyAny == null) {
                     current = next
                     continue@moveRightLoop
                 }
+                @Suppress("UNCHECKED_CAST")
+                val nextKey = nextKeyAny as K
 
                 current = when {
                     isEqual(key, nextKey) -> {
@@ -389,8 +389,8 @@ abstract class AbstractSkipList<K, V>(
     abstract fun updateKeyCache(node: K)
 
     companion object {
-        private fun <K> isGreater(key: K, key2: K?): Boolean = key2.forceCompare(key, QueryCriteriaOperator.GREATER_THAN)
-        private fun <K> isEqual(key: K, key2: K?): Boolean = key.forceCompare(key2, QueryCriteriaOperator.EQUAL)
+        private fun <K> isGreater(key: K, key2: K): Boolean = key2.forceCompare(key, QueryCriteriaOperator.GREATER_THAN)
+        private fun <K> isEqual(key: K, key2: K): Boolean = key.forceCompare(key2, QueryCriteriaOperator.EQUAL)
         private fun coinToss() = Math.random() < 0.3
 
         fun Any?.cast(type: Class<*>): Any? {


### PR DESCRIPTION
## Summary
- avoid loading `records` for sentinel nodes by returning null when a node's key reference is zero
- advance past nodes whose keys resolve to null during skip-list traversal, preventing NPEs in index range operations
- add tests for null index values and null DiskMap keys

## Testing
- `./gradlew test` *(fails: Failed to apply plugin 'dev.onyx.java-conventions'; null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_68c422f52e348327b0a470984a434dd8