### PR TITLE
Add unit tests for onyx-cloud-client

### DIFF
--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/DateTimeExtensionsTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/DateTimeExtensionsTest.kt
@@ -1,0 +1,54 @@
+package com.onyx.cloud
+
+import kotlin.test.*
+import com.onyx.cloud.extensions.parseToJavaDate
+import java.time.*
+import java.time.format.DateTimeFormatter
+
+/**
+ * Tests the `parseToJavaDate` extension across supported formats and edge cases.
+ */
+class DateTimeExtensionsTest {
+    @Test
+    fun parsesIsoInstant() {
+        val s = "2024-11-23T22:57:47Z"
+        val date = s.parseToJavaDate()
+        assertNotNull(date)
+        assertEquals(Instant.parse(s), date!!.toInstant())
+    }
+
+    @Test
+    fun parsesLocalDateTimeAsUtc() {
+        val s = "2024-11-23 22:57:47"
+        val date = s.parseToJavaDate()
+        val expected = LocalDateTime.parse(s, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+            .atZone(ZoneId.of("UTC")).toInstant()
+        assertNotNull(date)
+        assertEquals(expected, date!!.toInstant())
+    }
+
+    @Test
+    fun parsesDateOnlyToStartOfDayUtc() {
+        val s = "2024-11-23"
+        val date = s.parseToJavaDate()
+        val expected = LocalDate.parse(s).atStartOfDay(ZoneId.of("UTC")).toInstant()
+        assertNotNull(date)
+        assertEquals(expected, date!!.toInstant())
+    }
+
+    @Test
+    fun parsesIsoOffset() {
+        val s = "2024-11-23T22:57:47+02:00"
+        val date = s.parseToJavaDate()
+        val expected = OffsetDateTime.parse(s).toInstant()
+        assertNotNull(date)
+        assertEquals(expected, date!!.toInstant())
+    }
+
+    @Test
+    fun invalidFormatReturnsNull() {
+        val date = "not-a-date".parseToJavaDate()
+        assertNull(date)
+    }
+}
+

--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/JsonExtensionsTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/JsonExtensionsTest.kt
@@ -1,0 +1,62 @@
+package com.onyx.cloud
+
+import kotlin.test.*
+import com.onyx.cloud.extensions.*
+
+/**
+ * Verifies JSON serialization and deserialization helpers.
+ */
+class JsonExtensionsTest {
+    data class Person(val name: String, val age: Int)
+
+    @Test
+    fun serializeAndDeserializeRoundTrip() {
+        val person = Person("Alice", 30)
+        val json = person.toJson()
+        assertTrue(json.contains("Alice", ignoreCase = false))
+        val parsed = json.fromJson<Person>()
+        assertEquals(person, parsed)
+    }
+
+    @Test
+    fun fromJsonWithKClass() {
+        val json = """{"name":"Bob","age":25}"""
+        val parsed: Person = json.fromJson(Person::class)
+        assertEquals("Bob", parsed.name)
+        assertEquals(25, parsed.age)
+    }
+
+    @Test
+    fun fromJsonListParsesArray() {
+        val json = """[{"name":"A","age":1},{"name":"B","age":2}]"""
+        val list: List<Person>? = json.fromJsonList(Person::class.java)
+        assertNotNull(list)
+        assertEquals(2, list!!.size)
+        assertEquals("A", list[0].name)
+        assertEquals(2, list[1].age)
+    }
+
+    @Test
+    fun invalidJsonReturnsNull() {
+        val result = "{bad json".fromJson<Person>()
+        assertNull(result)
+    }
+
+    @Test
+    fun cyclicReferenceProducesPlaceholder() {
+        data class Node(var name: String, var child: Node? = null)
+        val parent = Node("parent")
+        parent.child = parent
+        val json = parent.toJson()
+        assertEquals("{\"name\":\"parent\"}", json)
+    }
+
+    @Test
+    fun listRoundTrip() {
+        val list = listOf(Person("A", 1), Person("B", 2))
+        val json = list.toJson()
+        val parsed: List<Person>? = json.fromJsonList(Person::class.java)
+        assertEquals(list, parsed)
+    }
+}
+

--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/OnyxClientTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/OnyxClientTest.kt
@@ -1,0 +1,42 @@
+package com.onyx.cloud
+
+import kotlin.test.*
+
+/**
+ * Exercises utility helpers within [OnyxClient].
+ */
+class OnyxClientTest {
+    private val client = OnyxClient(baseUrl = "http://localhost", databaseId = "db", apiKey = "k", apiSecret = "s")
+
+    private fun buildQuery(options: Map<String, Any?>): String {
+        val method = OnyxClient::class.java.getDeclaredMethod("buildQueryString", Map::class.java)
+        method.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return method.invoke(client, options) as String
+    }
+
+    @Test
+    fun encodeStringsProperly() {
+        assertEquals("hello+world%21", client.encode("hello world!"))
+    }
+
+    @Test
+    fun buildQueryStringHandlesListsAndNulls() {
+        val qs = buildQuery(mapOf("partition" to "users", "fetch" to listOf("friends", "groups"), "nullOpt" to null))
+        assertEquals("?partition=users&fetch=friends%2Cgroups", qs)
+    }
+
+    @Test
+    fun buildQueryStringEmptyMap() {
+        val qs = buildQuery(emptyMap())
+        assertEquals("", qs)
+    }
+
+    @Test
+    fun buildQueryStringWithNumbersAndBooleans() {
+        val qs = buildQuery(mapOf("limit" to 5, "active" to true))
+        assertTrue(qs.contains("limit=5", ignoreCase = false))
+        assertTrue(qs.contains("active=true", ignoreCase = false))
+    }
+}
+

--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/api/ConditionBuilderImplTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/api/ConditionBuilderImplTest.kt
@@ -1,0 +1,40 @@
+package com.onyx.cloud.api
+
+import kotlin.test.*
+
+/**
+ * Validates logical composition within [ConditionBuilderImpl].
+ */
+class ConditionBuilderImplTest {
+    @Test
+    fun combinesAndConditions() {
+        val builder = ConditionBuilderImpl(QueryCriteria("age", QueryCriteriaOperator.GREATER_THAN, 18))
+            .and(QueryCriteria("active", QueryCriteriaOperator.EQUAL, true))
+
+        val condition = builder.toCondition() as CompoundCondition
+        assertEquals(LogicalOperator.AND, condition.operator)
+        assertEquals(2, condition.conditions.size)
+    }
+
+    @Test
+    fun combinesOrConditionsWithBuilder() {
+        val first = ConditionBuilderImpl(QueryCriteria("city", QueryCriteriaOperator.EQUAL, "NY"))
+        val second = ConditionBuilderImpl(QueryCriteria("city", QueryCriteriaOperator.EQUAL, "LA"))
+        first.or(second)
+        val cond = first.toCondition() as CompoundCondition
+        assertEquals(LogicalOperator.OR, cond.operator)
+        assertEquals(2, cond.conditions.size)
+    }
+
+    @Test
+    fun orAfterAndAddsCondition() {
+        val base = ConditionBuilderImpl(QueryCriteria("age", QueryCriteriaOperator.GREATER_THAN, 18))
+            .and(QueryCriteria("active", QueryCriteriaOperator.EQUAL, true))
+        val city = ConditionBuilderImpl(QueryCriteria("city", QueryCriteriaOperator.EQUAL, "NY"))
+        base.or(city)
+        val cond = base.toCondition() as CompoundCondition
+        assertEquals(LogicalOperator.OR, cond.operator)
+        assertEquals(3, cond.conditions.size)
+    }
+}
+

--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/api/QueryResultsImplTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/api/QueryResultsImplTest.kt
@@ -1,0 +1,79 @@
+package com.onyx.cloud.api
+
+import kotlin.test.*
+import java.math.BigInteger
+
+/**
+ * Exercises pagination helpers provided by [QueryResultsImpl].
+ */
+class QueryResultsImplTest {
+    data class Record(val num: Int)
+
+    @Test
+    fun iteratesAcrossPagesAndAggregates() {
+        val page2 = QueryResultsImpl(listOf(Record(3), Record(4)))
+        val page1 = QueryResultsImpl(
+            records = listOf(Record(1), Record(2)),
+            nextPage = "token",
+            fetcher = { token ->
+                assertEquals("token", token)
+                page2
+            }
+        )
+
+        val all = page1.getAllRecords()
+        assertEquals(listOf(Record(1), Record(2), Record(3), Record(4)), all)
+
+        val values = page1.values("num")
+        assertEquals(listOf(1, 2, 3, 4), values)
+
+        assertEquals(4, page1.maxOfInt { it.num })
+        assertEquals(1, page1.minOfInt { it.num })
+        assertEquals(10, page1.sumOfInt { it.num })
+
+        assertEquals(BigInteger.valueOf(10), page1.sumOfBigInt { BigInteger.valueOf(it.num.toLong()) })
+
+        val pages = mutableListOf<List<Record>>()
+        page1.forEachPage { page -> pages.add(page); true }
+        assertEquals(2, pages.size)
+    }
+
+    @Test
+    fun firstThrowsWhenEmpty() {
+        val empty = QueryResultsImpl(emptyList<Record>())
+        assertFailsWith<IllegalStateException> { empty.first() }
+        assertNull(empty.firstOrNull())
+    }
+
+    @Test
+    fun filterAndMapAcrossPages() {
+        val page2 = QueryResultsImpl(listOf(Record(3), Record(4)))
+        val page1 = QueryResultsImpl(
+            records = listOf(Record(1), Record(2)),
+            nextPage = "token",
+            fetcher = { page2 }
+        )
+        assertEquals(listOf(Record(3), Record(4)), page1.filterAll { it.num > 2 })
+        assertEquals(listOf(2, 4, 6, 8), page1.mapAll { it.num * 2 })
+    }
+
+    @Test
+    fun valuesExtractFromMaps() {
+        val page = QueryResultsImpl(listOf(mapOf("name" to "A"), mapOf("name" to "B")))
+        val names = page.values("name")
+        assertEquals(listOf("A", "B"), names)
+    }
+
+    @Test
+    fun forEachPageStopsWhenFalse() {
+        var fetched = false
+        val page1 = QueryResultsImpl(
+            records = listOf(Record(1)),
+            nextPage = "token",
+            fetcher = { fetched = true; QueryResultsImpl(listOf(Record(2))) }
+        )
+        page1.forEachPage { false }
+        assertFalse(fetched)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add date parsing unit tests for `parseToJavaDate`
- test JSON serialization helpers, including list parsing and cyclical references
- cover client utilities, query builders, paginated result helpers, and add file-level KDocs

## Testing
- `./gradlew :onyx-cloud-client:test -PossrhUsername=foo -PossrhPassword=bar -Psigning.password=pass -Psigning.secretKey=ZHVtbXk= --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68c609f6c7f08327bb589980a013e2bb