### PR TITLE
Add integration test for update queries

### DIFF
--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/OnyxCloudIntegrationTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/OnyxCloudIntegrationTest.kt
@@ -117,6 +117,25 @@ class OnyxCloudIntegrationTest {
     }
 
     @Test
+    fun updateUserUsername() {
+        val now = Date()
+        val user = newUser(now)
+        client.save(user)
+        try {
+            val newUsername = "updated-${UUID.randomUUID().toString().substring(0, 8)}"
+            val updated = client.from<User>()
+                .where("id" eq user.id!!)
+                .setUpdates("username" to newUsername)
+                .update()
+            assertEquals(1, updated)
+            val fetched = client.findById<User>(user.id!!)
+            assertEquals(newUsername, fetched?.username)
+        } finally {
+            safeDelete("User", user.id!!)
+        }
+    }
+
+    @Test
     fun resolvesProfileAndRoles() {
         val now = Date()
         val role = newRole(now)


### PR DESCRIPTION
## Summary
- add update query integration test to verify updating user usernames through the Onyx Cloud API

## Testing
- `./gradlew onyx-cloud-client:test --stacktrace` *(fails: An exception occurred applying plugin request [id: 'dev.onyx.java-conventions']; null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_68c6192994c48327b873a93fae9b9fc6