### PR TITLE
test: add integration test for cloud update queries

### DIFF
--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/UpdateQueryIntegrationTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/UpdateQueryIntegrationTest.kt
@@ -1,0 +1,29 @@
+package com.onyx.cloud.integration
+
+import com.onyx.cloud.OnyxClient
+import com.onyx.cloud.eq
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import java.util.UUID
+
+/**
+ * Integration tests for update queries using the cloud client.
+ */
+class UpdateQueryIntegrationTest {
+    private val client = OnyxClient(
+        baseUrl = "https://api.onyx.dev",
+        databaseId = "bbabca0e-82ce-11f0-0000-a2ce78b61b6a",
+        apiKey = "Hj52NXaqB",
+        apiSecret = "bEJiEsuE28z1XeT/MHujy+1/6sqFMsZ4WK7M/M8BS34="
+    )
+
+    @Test
+    fun updateNonexistentRecordsReturnsZero() {
+        val updated = client.from<User>()
+            .where("username" eq "missing-${UUID.randomUUID()}")
+            .setUpdates("email" to "noop@example.com")
+            .update()
+
+        assertEquals(0, updated, "No rows should be updated when no records match")
+    }
+}


### PR DESCRIPTION
## Summary
- remove misplaced update test from onyx-database-tests module
- add onyx-cloud-client integration test ensuring update queries return zero when no records match

## Testing
- `./gradlew :onyx-database-tests:test --tests database.query.UpdateQueryTest --console=plain` *(fails: dev.onyx.java-conventions plugin: null cannot be cast to kotlin.String)*
- `./gradlew :onyx-cloud-client:test --tests com.onyx.cloud.integration.UpdateQueryIntegrationTest.updateNonexistentRecordsReturnsZero --console=plain` *(fails: dev.onyx.java-conventions plugin: null cannot be cast to kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_68c6191b8ca48327b0d9e70a93102362