### PR TITLE
test: add coverage for query operators

### DIFF
--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/QueryCriteriaOperatorIntegrationTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/QueryCriteriaOperatorIntegrationTest.kt
@@ -1,0 +1,186 @@
+package com.onyx.cloud.integration
+
+import com.onyx.cloud.OnyxClient
+import com.onyx.cloud.*
+import java.util.Date
+import java.util.UUID
+import kotlin.test.*
+
+/**
+ * Integration tests validating various query operators against the cloud backend.
+ */
+class QueryCriteriaOperatorIntegrationTest {
+    private val client = OnyxClient(
+        baseUrl = "https://api.onyx.dev",
+        databaseId = "bbabca0e-82ce-11f0-0000-a2ce78b61b6a",
+        apiKey = "Hj52NXaqB",
+        apiSecret = "bEJiEsuE28z1XeT/MHujy+1/6sqFMsZ4WK7M/M8BS34="
+    )
+
+    private fun safeDelete(table: String, id: String) {
+        try {
+            client.delete(table, id)
+        } catch (_: Exception) {
+            // ignore if already removed
+        }
+    }
+
+    private fun newUser(now: Date, suffix: String? = null) = User(
+        id = UUID.randomUUID().toString(),
+        username = "user-${suffix ?: UUID.randomUUID().toString().substring(0, 8)}",
+        email = "user${UUID.randomUUID().toString().substring(0, 8)}@example.com",
+        isActive = true,
+        createdAt = now,
+        updatedAt = now
+    )
+
+    @Test
+    fun inOperator() {
+        val now = Date()
+        val user1 = newUser(now)
+        val user2 = newUser(now)
+        client.save(user1)
+        client.save(user2)
+        try {
+            val results = client.from<User>()
+                .where("id" inOp listOf(user1.id!!, user2.id!!))
+                .list<User>()
+            val ids = results.records.map { it.id }
+            assertTrue(ids.containsAll(listOf(user1.id, user2.id)))
+        } finally {
+            safeDelete("User", user1.id!!)
+            safeDelete("User", user2.id!!)
+        }
+    }
+
+    @Test
+    fun notInOperator() {
+        val now = Date()
+        val user1 = newUser(now)
+        val user2 = newUser(now)
+        client.save(user1)
+        client.save(user2)
+        try {
+            val results = client.from<User>()
+                .where("id" notIn listOf(user1.id!!))
+                .list<User>()
+            val ids = results.records.map { it.id }
+            assertFalse(ids.contains(user1.id))
+            assertTrue(ids.contains(user2.id))
+        } finally {
+            safeDelete("User", user1.id!!)
+            safeDelete("User", user2.id!!)
+        }
+    }
+
+    @Test
+    fun betweenOperator() {
+        val now = Date()
+        val user = newUser(now)
+        client.save(user)
+        try {
+            val start = Date(now.time - 1000)
+            val end = Date(now.time + 1000)
+            val results = client.from<User>()
+                .where("createdAt".between(start, end))
+                .and("id" eq user.id!!)
+                .list<User>()
+            assertTrue(results.records.any { it.id == user.id })
+        } finally {
+            safeDelete("User", user.id!!)
+        }
+    }
+
+    @Test
+    fun likeOperator() {
+        val now = Date()
+        val user = newUser(now, suffix = "like-test")
+        client.save(user)
+        try {
+            val results = client.from<User>()
+                .where("username".like("%like-test"))
+                .list<User>()
+            assertTrue(results.records.any { it.id == user.id })
+        } finally {
+            safeDelete("User", user.id!!)
+        }
+    }
+
+    @Test
+    fun matchesOperator() {
+        val now = Date()
+        val user = newUser(now, suffix = "regex-test")
+        client.save(user)
+        try {
+            val results = client.from<User>()
+                .where("username".matches("user-regex-test.*"))
+                .list<User>()
+            assertTrue(results.records.any { it.id == user.id })
+        } finally {
+            safeDelete("User", user.id!!)
+        }
+    }
+
+    @Test
+    fun containsOperator() {
+        val now = Date()
+        val user = newUser(now, suffix = "contains")
+        client.save(user)
+        try {
+            val results = client.from<User>()
+                .where("username".contains("contain"))
+                .list<User>()
+            assertTrue(results.records.any { it.id == user.id })
+        } finally {
+            safeDelete("User", user.id!!)
+        }
+    }
+
+    @Test
+    fun containsIgnoreCaseOperator() {
+        val now = Date()
+        val user = newUser(now, suffix = "CaseTest")
+        client.save(user)
+        try {
+            val results = client.from<User>()
+                .where("username".containsIgnoreCase("casetest"))
+                .list<User>()
+            assertTrue(results.records.any { it.id == user.id })
+        } finally {
+            safeDelete("User", user.id!!)
+        }
+    }
+
+    @Test
+    fun notContainsOperator() {
+        val now = Date()
+        val user = newUser(now, suffix = "nocontain")
+        client.save(user)
+        try {
+            val results = client.from<User>()
+                .where("username".notContains("xyz"))
+                .and("id" eq user.id!!)
+                .list<User>()
+            assertTrue(results.records.any { it.id == user.id })
+        } finally {
+            safeDelete("User", user.id!!)
+        }
+    }
+
+    @Test
+    fun notContainsIgnoreCaseOperator() {
+        val now = Date()
+        val user = newUser(now, suffix = "nocase")
+        client.save(user)
+        try {
+            val results = client.from<User>()
+                .where("username".notContainsIgnoreCase("xyz"))
+                .and("id" eq user.id!!)
+                .list<User>()
+            assertTrue(results.records.any { it.id == user.id })
+        } finally {
+            safeDelete("User", user.id!!)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add onyx-cloud-client integration tests covering QueryCriteria operators including IN/NOT_IN, BETWEEN, LIKE, MATCHES, and string containment variants

## Testing
- `./gradlew :onyx-cloud-client:test --tests com.onyx.cloud.integration.QueryCriteriaOperatorIntegrationTest` *(fails: Failed to apply plugin 'dev.onyx.java-conventions')*

------
https://chatgpt.com/codex/tasks/task_e_68c6199bfba88327850a3a1a52ca09b6