### PR TITLE
Avoid sending null resolver payloads

### DIFF
--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/Entities.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/Entities.kt
@@ -15,9 +15,9 @@ data class User(
     var updatedAt: Date? = null,
     var deletedAt: Date? = null,
     // Resolvers
-    var roles: List<Role>? = null,
-    var profile: UserProfile? = null,
-    var userRoles: List<UserRole>? = null,
+    @Transient var roles: List<Role>? = null,
+    @Transient var profile: UserProfile? = null,
+    @Transient var userRoles: List<UserRole>? = null,
 )
 
 data class UserProfile(
@@ -44,8 +44,8 @@ data class Role(
     var updatedAt: Date? = null,
     var deletedAt: Date? = null,
     // Resolvers
-    var permissions: List<Permission>? = null,
-    var rolePermissions: List<RolePermission>? = null,
+    @Transient var permissions: List<Permission>? = null,
+    @Transient var rolePermissions: List<RolePermission>? = null,
 )
 
 data class Permission(
@@ -63,7 +63,7 @@ data class UserRole(
     var roleId: String? = null,
     var createdAt: Date? = null,
     // Resolver
-    var role: Role? = null,
+    @Transient var role: Role? = null,
 )
 
 data class RolePermission(
@@ -72,6 +72,6 @@ data class RolePermission(
     var permissionId: String? = null,
     var createdAt: Date? = null,
     // Resolvers
-    var permission: Permission? = null,
-    var role: Role? = null,
+    @Transient var permission: Permission? = null,
+    @Transient var role: Role? = null,
 )


### PR DESCRIPTION
## Summary
- mark resolver fields in test entity models as `@Transient`
- prevent null resolver payloads from being sent to the API

## Testing
- `./gradlew :onyx-cloud-client:test --tests com.onyx.cloud.integration.QueryCriteriaOperatorIntegrationTest.notInOperator` *(fails: Null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_68c61d6289bc832789c048846929777c