### PR TITLE
Ensure update payload uses string values

### DIFF
--- a/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/OnyxClient.kt
+++ b/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/OnyxClient.kt
@@ -843,7 +843,7 @@ class QueryBuilder internal constructor(
         mapOf(
             "type" to "UpdateQuery",
             "conditions" to conditions,
-            "updates" to updates,
+            "updates" to updates?.mapValues { it.value?.toString() },
             "partition" to partitionValue
         ).filterValues { it != null && !(it is List<*> && it.isEmpty()) }
 

--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/UpdatePayloadSerializationTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/UpdatePayloadSerializationTest.kt
@@ -1,0 +1,21 @@
+package com.onyx.cloud
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UpdatePayloadSerializationTest {
+    @Test
+    fun numericUpdateValuesAreConvertedToStrings() {
+        val client = OnyxClient(baseUrl = "https://example.com", databaseId = "db", apiKey = "key", apiSecret = "secret")
+        val builder = client.from("Users").setUpdates("age" to 30)
+
+        val method = builder::class.java.getDeclaredMethod("buildUpdateQueryPayload")
+        method.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val payload = method.invoke(builder) as Map<String, Any?>
+        val updates = payload["updates"] as Map<*, *>
+
+        assertEquals("30", updates["age"])
+    }
+}
+


### PR DESCRIPTION
## Summary
- convert update query payload values to strings to match server expectations
- add unit test verifying numeric updates are stringified

## Testing
- `./gradlew :onyx-cloud-client:test` *(fails: Failed to apply plugin 'dev.onyx.java-conventions'. null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_68c61dcb662c83278d33366f0ce64333