### PR TITLE
Handle missing credentials and omit null JSON

### DIFF
--- a/buildSrc/src/main/kotlin/dev.onyx.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.onyx.java-conventions.gradle.kts
@@ -41,8 +41,12 @@ fun base64Decode(prop: String): String? {
 }
 
 signing {
-    useInMemoryPgpKeys(base64Decode("signing.secretKey"), project.findProperty("signing.password") as String)
-    sign(publishing.publications)
+    val secretKey = base64Decode("signing.secretKey")
+    val password = project.findProperty("signing.password") as String?
+    if (secretKey != null && password != null) {
+        useInMemoryPgpKeys(secretKey, password)
+        sign(publishing.publications)
+    }
 }
 
 publishing {
@@ -50,9 +54,13 @@ publishing {
     repositories {
         maven {
             url = URI("https://maven.pkg.github.com/OnyxDevTools/onyx-database-parent")
-            credentials {
-                username = project.property("ossrhUsername") as String
-                password = project.property("ossrhPassword") as String
+            val ossrhUsername = project.findProperty("ossrhUsername") as String?
+            val ossrhPassword = project.findProperty("ossrhPassword") as String?
+            if (ossrhUsername != null && ossrhPassword != null) {
+                credentials {
+                    username = ossrhUsername
+                    password = ossrhPassword
+                }
             }
         }
     }

--- a/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/extensions/GsonConfig.kt
+++ b/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/extensions/GsonConfig.kt
@@ -105,7 +105,7 @@ private val kotlinDelegateExclusionStrategy = object : ExclusionStrategy {
  * Configuration includes:
  * - Enabling complex map key serialization.
  * - Serializing special floating-point values (NaN, Infinity).
- * - Serializing null values.
+ * - Omitting null fields to avoid sending explicit nulls for unset properties.
  * - Excluding Kotlin synthetic delegate fields (`$delegate`).
  * - Registering a `CyclicTypeAdapterFactory` to handle object graph cycles.
  * - Registering custom adapters for `java.util.Date` serialization and deserialization.
@@ -114,7 +114,7 @@ private val kotlinDelegateExclusionStrategy = object : ExclusionStrategy {
 val gson: Gson = GsonBuilder()
     .enableComplexMapKeySerialization() // Allow non-primitive map keys
     .serializeSpecialFloatingPointValues() // Handle NaN, Infinity
-    .serializeNulls() // Output null fields explicitly
+    // Do not serialize nulls to prevent null relationship payloads
     .addSerializationExclusionStrategy(kotlinDelegateExclusionStrategy)
     .addDeserializationExclusionStrategy(kotlinDelegateExclusionStrategy)
     .registerTypeAdapterFactory(CyclicTypeAdapterFactory()) // Handle cyclical references


### PR DESCRIPTION
## Summary
- Avoid Gradle plugin crashes by loading signing and publishing credentials only when present
- Skip serializing null fields in Gson to prevent invalid cascade payloads when calling the cloud API

## Testing
- `./gradlew onyx-cloud-client:test --tests "*QueryCriteriaOperatorIntegrationTest.likeOperator" --console=plain -q` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68c61f4a31cc832796f89faf44dc2bed