### PR TITLE
Avoid null JSON fields in cloud client requests

### DIFF
--- a/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/extensions/GsonConfig.kt
+++ b/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/extensions/GsonConfig.kt
@@ -104,7 +104,7 @@ private val kotlinDelegateExclusionStrategy = object : ExclusionStrategy {
  * Configuration includes:
  * - Enabling complex map key serialization.
  * - Serializing special floating-point values (NaN, Infinity).
- * - Serializing null values.
+ * - Omitting properties with null values to avoid sending explicit nulls.
  * - Excluding Kotlin synthetic delegate fields (`$delegate`).
  * - Registering a `CyclicTypeAdapterFactory` to handle object graph cycles.
  * - Registering custom adapters for `java.util.Date` serialization and deserialization.
@@ -113,7 +113,6 @@ private val kotlinDelegateExclusionStrategy = object : ExclusionStrategy {
 val gson: Gson = GsonBuilder()
     .enableComplexMapKeySerialization() // Allow non-primitive map keys
     .serializeSpecialFloatingPointValues() // Handle NaN, Infinity
-    .serializeNulls() // Output null fields explicitly
     .addSerializationExclusionStrategy(kotlinDelegateExclusionStrategy)
     .addDeserializationExclusionStrategy(kotlinDelegateExclusionStrategy)
     .registerTypeAdapterFactory(CyclicTypeAdapterFactory()) // Handle cyclical references


### PR DESCRIPTION
## Summary
- avoid serializing null values in the shared Gson configuration to prevent sending `payload: null`

## Testing
- `./gradlew test` *(fails: null cannot be cast to non-null type kotlin.String)*

------
https://chatgpt.com/codex/tasks/task_e_68c621b9f0fc8327bad7052b1291a312