### PR TITLE
Wrap save payloads for cascade serialization

### DIFF
--- a/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/OnyxClient.kt
+++ b/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/OnyxClient.kt
@@ -99,13 +99,23 @@ class OnyxClient(
      */
     fun <T : Any> save(table: KClass<*>, entityOrEntities: T): T {
         val path = "/data/${encode(databaseId)}/${encode(table)}"
+        val payload = buildCascadePayload(entityOrEntities as Any)
         return if (entityOrEntities is List<*>) {
-            makeRequest(HttpMethod.Put, path, entityOrEntities)
+            makeRequest(HttpMethod.Put, path, payload)
             entityOrEntities
         } else {
-            makeRequest(HttpMethod.Put, path, entityOrEntities).fromJson(table)
+            makeRequest(HttpMethod.Put, path, payload).fromJson(table)
                 ?: throw IllegalStateException("Failed to parse response for save single entity")
         }
+    }
+
+    private fun buildCascadePayload(entityOrEntities: Any): Map<String, Any?> {
+        val wrapped = if (entityOrEntities is List<*>) {
+            mapOf("items" to entityOrEntities)
+        } else {
+            mapOf("single" to entityOrEntities)
+        }
+        return mapOf("payload" to wrapped)
     }
 
     /**

--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/CascadePayloadSerializationTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/CascadePayloadSerializationTest.kt
@@ -1,0 +1,31 @@
+package com.onyx.cloud
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CascadePayloadSerializationTest {
+    @Test
+    fun wrapsSingleEntity() {
+        val client = OnyxClient(baseUrl = "https://example.com", databaseId = "db", apiKey = "key", apiSecret = "secret")
+        val method = OnyxClient::class.java.getDeclaredMethod("buildCascadePayload", Any::class.java)
+        method.isAccessible = true
+        val entity = mapOf("id" to "1", "name" to "Test")
+        @Suppress("UNCHECKED_CAST")
+        val payload = method.invoke(client, entity) as Map<String, Any?>
+        val inner = payload["payload"] as Map<*, *>
+        assertEquals(entity, inner["single"])
+    }
+
+    @Test
+    fun wrapsEntityList() {
+        val client = OnyxClient(baseUrl = "https://example.com", databaseId = "db", apiKey = "key", apiSecret = "secret")
+        val method = OnyxClient::class.java.getDeclaredMethod("buildCascadePayload", Any::class.java)
+        method.isAccessible = true
+        val entities = listOf(mapOf("id" to "1"), mapOf("id" to "2"))
+        @Suppress("UNCHECKED_CAST")
+        val payload = method.invoke(client, entities) as Map<String, Any?>
+        val inner = payload["payload"] as Map<*, *>
+        assertEquals(entities, inner["items"])
+    }
+}
+


### PR DESCRIPTION
## Summary
- Wrap single and bulk save requests in a `payload` wrapper to match cascade expectations
- Add unit tests confirming cascade payload structure for single entities and lists

## Testing
- `./gradlew test` *(fails: 48 tests completed, 22 failed)*
- `./gradlew :onyx-cloud-client:test --tests com.onyx.cloud.CascadePayloadSerializationTest --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68c6297266a483278f3f6b1c52008a06