### PR TITLE
Remove coroutine usage from onyx-cloud-client streaming

### DIFF
--- a/onyx-cloud-client/build.gradle.kts
+++ b/onyx-cloud-client/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 
 dependencies {
     implementation("com.google.code.gson:gson:${Config.GSON_VERSION}")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
 
 }
 

--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/OnyxCloudStreamingIntegrationTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/OnyxCloudStreamingIntegrationTest.kt
@@ -1,11 +1,8 @@
 package com.onyx.cloud.integration
 
 import com.onyx.cloud.OnyxClient
+import com.onyx.cloud.StreamSubscription
 import com.onyx.cloud.eq
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import java.util.Date
 import java.util.UUID
 import kotlin.test.Test
@@ -36,64 +33,66 @@ class OnyxCloudStreamingIntegrationTest {
     }
 
     @Test
-    fun streamIncludesQueryResults() = runBlocking {
+    fun streamIncludesQueryResults() {
         val now = Date()
         val initialUser = newUser(now, isActive = true)
         val createdUser = newUser(now, isActive = true)
         client.save(initialUser)
+        var subscription: StreamSubscription? = null
         try {
             val initial = mutableListOf<User>()
             val added = mutableListOf<User>()
-            val job = launch {
-                client.from<User>()
-                    .where("isActive" eq true)
-                    .onItem<User> { initial.add(it) }
-                    .onItemAdded<User> { added.add(it) }
-                    .stream<User>(includeQueryResults = true, keepAlive = true)
-            }
+            subscription = client.from<User>()
+                .where("isActive" eq true)
+                .onItem<User> { initial.add(it) }
+                .onItemAdded<User> { added.add(it) }
+                .stream<User>(includeQueryResults = true, keepAlive = true)
 
-            delay(1000)
+            Thread.sleep(1000)
             client.save(createdUser)
-            delay(1000)
-            job.cancelAndJoin()
+            Thread.sleep(1000)
+            subscription.cancelAndJoin()
+            subscription = null
 
             assertTrue(initial.any { it.id == initialUser.id })
             assertTrue(added.any { it.id == createdUser.id })
         } finally {
+            subscription?.cancelAndJoin()
             safeDelete(initialUser.id)
             safeDelete(createdUser.id)
         }
     }
 
     @Test
-    fun streamWithPredicate() = runBlocking {
+    fun streamWithPredicate() {
         val now = Date()
         val inactiveInitial = newUser(now, isActive = false)
         val inactiveCreated = newUser(now, isActive = false)
         val activeCreated = newUser(now, isActive = true)
         client.save(inactiveInitial)
+        var subscription: StreamSubscription? = null
         try {
             val initial = mutableListOf<User>()
             val added = mutableListOf<User>()
-            val job = launch {
-                client.from<User>()
-                    .where("isActive" eq false)
-                    .onItem<User> { initial.add(it) }
-                    .onItemAdded<User> { added.add(it) }
-                    .stream<User>(includeQueryResults = true, keepAlive = true)
-            }
+            subscription = client.from<User>()
+                .where("isActive" eq false)
+                .onItem<User> { initial.add(it) }
+                .onItemAdded<User> { added.add(it) }
+                .stream<User>(includeQueryResults = true, keepAlive = true)
 
-            delay(1000)
+            Thread.sleep(1000)
             client.save(inactiveCreated)
-            delay(500)
+            Thread.sleep(500)
             client.save(activeCreated)
-            delay(1000)
-            job.cancelAndJoin()
+            Thread.sleep(1000)
+            subscription.cancelAndJoin()
+            subscription = null
 
             assertTrue(initial.any { it.id == inactiveInitial.id })
             assertTrue(added.any { it.id == inactiveCreated.id })
             assertTrue(added.none { it.id == activeCreated.id })
         } finally {
+            subscription?.cancelAndJoin()
             safeDelete(inactiveInitial.id)
             safeDelete(inactiveCreated.id)
             safeDelete(activeCreated.id)
@@ -101,76 +100,82 @@ class OnyxCloudStreamingIntegrationTest {
     }
 
     @Test
-    fun addSaveListenerWithoutQueryResults() = runBlocking {
+    fun addSaveListenerWithoutQueryResults() {
         val now = Date()
         val toCreate = newUser(now, isActive = true)
         val initial = mutableListOf<User>()
         val added = mutableListOf<User>()
-        val job = launch {
-            client.from<User>()
+        var subscription: StreamSubscription? = null
+        try {
+            subscription = client.from<User>()
                 .where("isActive" eq true)
                 .onItem<User> { initial.add(it) }
                 .onItemAdded<User> { added.add(it) }
                 .stream<User>(includeQueryResults = false, keepAlive = true)
+
+            Thread.sleep(1000)
+            client.save(toCreate)
+            Thread.sleep(1000)
+            subscription.cancelAndJoin()
+            subscription = null
+
+            assertTrue(initial.isEmpty())
+            assertTrue(added.any { it.id == toCreate.id })
+        } finally {
+            subscription?.cancelAndJoin()
+            safeDelete(toCreate.id)
         }
-
-        delay(1000)
-        client.save(toCreate)
-        delay(1000)
-        job.cancelAndJoin()
-
-        assertTrue(initial.isEmpty())
-        assertTrue(added.any { it.id == toCreate.id })
-        safeDelete(toCreate.id)
     }
 
     @Test
-    fun addDeleteListenerWithoutQueryResults() = runBlocking {
+    fun addDeleteListenerWithoutQueryResults() {
         val now = Date()
         val toDelete = newUser(now, isActive = true)
         client.save(toDelete)
+        var subscription: StreamSubscription? = null
         try {
             val deleted = mutableListOf<User>()
-            val job = launch {
-                client.from<User>()
-                    .where("id" eq toDelete.id!!)
-                    .onItemDeleted<User> { deleted.add(it) }
-                    .stream<User>(includeQueryResults = false, keepAlive = true)
-            }
+            subscription = client.from<User>()
+                .where("id" eq toDelete.id!!)
+                .onItemDeleted<User> { deleted.add(it) }
+                .stream<User>(includeQueryResults = false, keepAlive = true)
 
-            delay(1000)
+            Thread.sleep(1000)
             client.delete("User", toDelete.id!!)
-            delay(1000)
-            job.cancelAndJoin()
+            Thread.sleep(1000)
+            subscription.cancelAndJoin()
+            subscription = null
 
             assertTrue(deleted.any { it.id == toDelete.id })
         } finally {
+            subscription?.cancelAndJoin()
             safeDelete(toDelete.id)
         }
     }
 
     @Test
-    fun addUpdateListenerWithoutQueryResults() = runBlocking {
+    fun addUpdateListenerWithoutQueryResults() {
         val now = Date()
         val toUpdate = newUser(now, isActive = true)
         client.save(toUpdate)
+        var subscription: StreamSubscription? = null
         try {
             val updated = mutableListOf<User>()
-            val job = launch {
-                client.from<User>()
-                    .where("id" eq toUpdate.id!!)
-                    .onItemUpdated<User> { updated.add(it) }
-                    .stream<User>(includeQueryResults = false, keepAlive = true)
-            }
+            subscription = client.from<User>()
+                .where("id" eq toUpdate.id!!)
+                .onItemUpdated<User> { updated.add(it) }
+                .stream<User>(includeQueryResults = false, keepAlive = true)
 
-            delay(1000)
+            Thread.sleep(1000)
             toUpdate.username = "updated-${UUID.randomUUID().toString().substring(0, 8)}"
             client.save(toUpdate)
-            delay(1000)
-            job.cancelAndJoin()
+            Thread.sleep(1000)
+            subscription.cancelAndJoin()
+            subscription = null
 
             assertTrue(updated.any { it.id == toUpdate.id && it.username == toUpdate.username })
         } finally {
+            subscription?.cancelAndJoin()
             safeDelete(toUpdate.id)
         }
     }


### PR DESCRIPTION
## Summary
- replace the Flow-based stream implementation with a thread-backed `StreamSubscription` that invokes a caller-provided line handler
- update the query builder streaming helpers and integration tests to consume the new subscription API without coroutines
- drop the `kotlinx-coroutines` dependency from the cloud client module

## Testing
- ./gradlew :onyx-cloud-client:test *(fails: SocketException when contacting the remote API)*


------
https://chatgpt.com/codex/tasks/task_e_68c8b05bd1b883278cc5e05f09192692