### PR TITLE
Add integration tests for query sorting

### DIFF
--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/QuerySortOrderIntegrationTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/QuerySortOrderIntegrationTest.kt
@@ -1,0 +1,90 @@
+package com.onyx.cloud.integration
+
+import com.onyx.cloud.OnyxClient
+import com.onyx.cloud.*
+import java.util.Date
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Integration tests validating that query sorting works against the cloud backend.
+ */
+class QuerySortOrderIntegrationTest {
+    private val client = OnyxClient(
+        baseUrl = "https://api.onyx.dev",
+        databaseId = "bbabca0e-82ce-11f0-0000-a2ce78b61b6a",
+        apiKey = "Hj52NXaqB",
+        apiSecret = "bEJiEsuE28z1XeT/MHujy+1/6sqFMsZ4WK7M/M8BS34="
+    )
+
+    private fun safeDelete(table: String, id: String) {
+        try {
+            client.delete(table, id)
+        } catch (_: Exception) {
+            // ignore if already removed
+        }
+    }
+
+    private fun newUser(username: String, now: Date) = User(
+        id = UUID.randomUUID().toString(),
+        username = username,
+        email = "${username}-${UUID.randomUUID().toString().substring(0, 8)}@example.com",
+        isActive = true,
+        createdAt = now,
+        updatedAt = now
+    )
+
+    private fun createUsers(usernames: List<String>): List<User> {
+        val baseTime = Date()
+        return usernames.mapIndexed { index, username ->
+            client.save(newUser(username, Date(baseTime.time + index * 1000L)))
+        }
+    }
+
+    @Test
+    fun orderByAscendingReturnsRecordsInAscendingOrder() {
+        val prefix = "sort-asc-${UUID.randomUUID().toString().substring(0, 8)}"
+        val usernames = listOf("$prefix-c", "$prefix-a", "$prefix-b")
+        val savedUsers = createUsers(usernames)
+        val expectedOrder = savedUsers.mapNotNull { it.username }.sorted()
+        val ids = savedUsers.map { it.id!! }
+
+        try {
+            val results = client.from<User>()
+                .where("id" inOp ids)
+                .orderBy(asc("username"))
+                .list<User>()
+
+            val actualOrder = results.records.mapNotNull { it.username }
+            assertEquals(expectedOrder, actualOrder)
+        } finally {
+            savedUsers.forEach { user ->
+                user.id?.let { safeDelete("User", it) }
+            }
+        }
+    }
+
+    @Test
+    fun orderByDescendingReturnsRecordsInDescendingOrder() {
+        val prefix = "sort-desc-${UUID.randomUUID().toString().substring(0, 8)}"
+        val usernames = listOf("$prefix-a", "$prefix-c", "$prefix-b")
+        val savedUsers = createUsers(usernames)
+        val expectedOrder = savedUsers.mapNotNull { it.username }.sortedDescending()
+        val ids = savedUsers.map { it.id!! }
+
+        try {
+            val results = client.from<User>()
+                .where("id" inOp ids)
+                .orderBy(desc("username"))
+                .list<User>()
+
+            val actualOrder = results.records.mapNotNull { it.username }
+            assertEquals(expectedOrder, actualOrder)
+        } finally {
+            savedUsers.forEach { user ->
+                user.id?.let { safeDelete("User", it) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new integration test suite that exercises ascending and descending order queries against the shared cloud database connection
- seed and clean up temporary users within each test to verify deterministic ordering results

## Testing
- ./gradlew :onyx-cloud-client:test *(fails: integration tests cannot reach api.onyx.dev from CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d2827154832790e01cc9c78d3b7f