### PR TITLE
Add integration tests for batch user saves

### DIFF
--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/OnyxCloudIntegrationTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/OnyxCloudIntegrationTest.kt
@@ -199,6 +199,47 @@ class OnyxCloudIntegrationTest {
     }
 
     @Test
+    fun saveMultipleUsersInSingleRequest() {
+        val now = Date()
+        val users = List(3) { newUser(now) }
+
+        try {
+            client.save(User::class, users)
+            users.forEach { user ->
+                val fetched = client.findById<User>(user.id!!)
+                assertNotNull(fetched, "User ${user.id} should exist after batch save")
+                assertEquals(user.username, fetched.username)
+            }
+        } finally {
+            users.forEach { user -> safeDelete("User", user.id!!) }
+        }
+    }
+
+    @Test
+    fun updateMultipleUsersInSingleRequest() {
+        val now = Date()
+        val users = List(2) { newUser(now) }
+
+        try {
+            client.save(User::class, users)
+
+            users.forEach { user ->
+                user.username = "batch-updated-${UUID.randomUUID().toString().substring(0, 8)}"
+                user.updatedAt = Date()
+            }
+
+            client.save(User::class, users)
+            users.forEach { user ->
+                val fetched = client.findById<User>(user.id!!)
+                assertNotNull(fetched, "User ${user.id} should be updated after batch save")
+                assertEquals(user.username, fetched.username)
+            }
+        } finally {
+            users.forEach { user -> safeDelete("User", user.id!!) }
+        }
+    }
+
+    @Test
     fun groupByActiveUsers() {
         client.from<User>().delete()
         val now = Date()


### PR DESCRIPTION
## Summary
- add integration coverage for saving multiple users in a single request
- verify batch saving can update multiple users in one call as well

## Testing
- ./gradlew :onyx-cloud-client:test *(fails: SocketException when reaching the remote API)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d1622b5c8327be1b5a0bc4543f1c