### PR TITLE
Add integration tests for document operations

### DIFF
--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/DocumentIntegrationTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/DocumentIntegrationTest.kt
@@ -1,0 +1,81 @@
+package com.onyx.cloud.integration
+
+import com.onyx.cloud.Document
+import com.onyx.cloud.OnyxClient
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import java.util.Date
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Suppress("unused")
+private val enforceIpv4Stack = run {
+    System.setProperty("java.net.preferIPv4Stack", "true")
+    System.setProperty("java.net.preferIPv6Addresses", "false")
+}
+
+/**
+ * Integration tests for document endpoints against the shared Onyx Cloud database.
+ */
+class DocumentIntegrationTest {
+    private val client = OnyxClient(
+        baseUrl = "https://api.onyx.dev",
+        databaseId = "bbabca0e-82ce-11f0-0000-a2ce78b61b6a",
+        apiKey = "Hj52NXaqB",
+        apiSecret = "bEJiEsuE28z1XeT/MHujy+1/6sqFMsZ4WK7M/M8BS34="
+    )
+
+    private fun newDocument(): Document {
+        val documentId = UUID.randomUUID().toString()
+        val now = Date()
+        val plainContent = "Integration document ${'$'}{UUID.randomUUID()}"
+        val encodedContent = Base64.getEncoder().encodeToString(plainContent.toByteArray(StandardCharsets.UTF_8))
+        return Document(
+            documentId = documentId,
+            path = "/integration/tests/${'$'}documentId.txt",
+            created = now,
+            updated = now,
+            mimeType = "text/plain",
+            content = encodedContent
+        )
+    }
+
+    private fun cleanupDocument(documentId: String) {
+        try {
+            client.deleteDocument(documentId)
+        } catch (_: Exception) {
+            // Best-effort cleanup. Ignore network errors during teardown.
+        }
+    }
+
+    @Test
+    fun saveDocumentReturnsServerMetadata() {
+        val document = newDocument()
+        val saved = client.saveDocument(document)
+        try {
+            assertEquals(document.documentId, saved.documentId)
+            assertEquals(document.path, saved.path)
+            assertEquals(document.mimeType, saved.mimeType)
+            assertTrue(saved.created.time > 0)
+            assertTrue(saved.updated.time > 0)
+            assertTrue(saved.content.isEmpty(), "Server response should not echo document content")
+        } finally {
+            cleanupDocument(document.documentId)
+        }
+    }
+
+    @Test
+    fun getDocumentReturnsOriginalContent() {
+        val document = newDocument()
+        client.saveDocument(document)
+        val expectedContent = String(Base64.getDecoder().decode(document.content), StandardCharsets.UTF_8)
+        try {
+            val fetched = client.getDocument(document.documentId)
+            assertEquals(expectedContent, fetched)
+        } finally {
+            cleanupDocument(document.documentId)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a document-focused integration test class exercising save and fetch operations against the shared cloud database
- ensure document fixtures include unique ids, base64-encoded content, and best-effort cleanup for uploaded records
- force IPv4 networking in the test context to match existing integration usage

## Testing
- `./gradlew :onyx-cloud-client:test --tests "com.onyx.cloud.integration.DocumentIntegrationTest"` *(fails: java.net.SocketException: Network is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d147f62c8327aeffc27c9bc2ecec