### PR TITLE
Add integration tests for query functions

### DIFF
--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/SelectFunctionsIntegrationTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/integration/SelectFunctionsIntegrationTest.kt
@@ -2,11 +2,17 @@ package com.onyx.cloud.integration
 
 import com.onyx.cloud.OnyxClient
 import com.onyx.cloud.avg
+import com.onyx.cloud.count
 import com.onyx.cloud.eq
+import com.onyx.cloud.lower
 import com.onyx.cloud.max
+import com.onyx.cloud.median
 import com.onyx.cloud.min
+import com.onyx.cloud.replace
 import com.onyx.cloud.std
+import com.onyx.cloud.substring
 import com.onyx.cloud.sum
+import com.onyx.cloud.upper
 import java.util.Date
 import java.util.UUID
 import kotlin.test.Test
@@ -67,7 +73,17 @@ class SelectFunctionsIntegrationTest {
 
         try {
             val results = client.from("UserProfile")
-                .select(min("age"), max("age"), avg("age"), sum("age"), std("age"))
+                .select(
+                    min("age"),
+                    max("age"),
+                    avg("age"),
+                    sum("age"),
+                    count("age"),
+                    median("age"),
+                    std("age"),
+                    variance("age"),
+                    percentile("age", 75.0),
+                )
                 .where("lastName" eq marker)
                 .list<Map<String, Any?>>()
                 .records
@@ -78,13 +94,21 @@ class SelectFunctionsIntegrationTest {
             val maxAge = (record["max(age)"] as Number).toInt()
             val sumAges = (record["sum(age)"] as Number).toInt()
             val avgAge = (record["avg(age)"] as Number).toDouble()
+            val countAge = (record["count(age)"] as Number).toInt()
+            val medianAge = (record["median(age)"] as Number).toDouble()
             val stdAge = (record["std(age)"] as Number).toDouble()
+            val varianceAge = (record["variance(age)"] as Number).toDouble()
+            val percentileAge = (record["percentile(age, 75.0)"] as Number).toDouble()
 
             assertEquals(21, minAge, "Unexpected minimum age")
             assertEquals(63, maxAge, "Unexpected maximum age")
             assertEquals(126, sumAges, "Unexpected sum of ages")
             assertEquals(42.0, avgAge, 0.001, "Unexpected average age")
+            assertEquals(ages.size, countAge, "Unexpected count of ages")
+            assertEquals(42.0, medianAge, 0.001, "Unexpected median age")
             assertEquals(17.146428199482248, stdAge, 0.001, "Unexpected standard deviation")
+            assertEquals(294.0, varianceAge, 0.001, "Unexpected variance")
+            assertEquals(52.5, percentileAge, 0.001, "Unexpected 75th percentile")
         } finally {
             savedPairs.forEach { (user, profile) ->
                 safeDelete("UserProfile", profile.id)
@@ -92,4 +116,41 @@ class SelectFunctionsIntegrationTest {
             }
         }
     }
+
+    @Test
+    fun selectStringFunctionsForUserProfiles() {
+        val now = Date()
+        val marker = "func-${UUID.randomUUID().toString().substring(0, 8)}"
+        val lastName = "Function-$marker"
+
+        val user = client.save(newUser(now))
+        val profile = client.save(newProfile(user.id!!, now, lastName, 33))
+
+        try {
+            val results = client.from("UserProfile")
+                .select(
+                    upper("lastName"),
+                    lower("lastName"),
+                    substring("lastName", 0, "Function".length),
+                    replace("lastName", "-", "_"),
+                )
+                .where("lastName" eq lastName)
+                .list<Map<String, Any?>>()
+                .records
+
+            val record = results.firstOrNull() ?: fail("Expected string function results for marker $marker")
+
+            assertEquals(lastName.uppercase(), record["upper(lastName)"]?.toString(), "Unexpected uppercase result")
+            assertEquals(lastName.lowercase(), record["lower(lastName)"]?.toString(), "Unexpected lowercase result")
+            assertEquals("Function", record["substring(lastName, 0, 8)"]?.toString(), "Unexpected substring result")
+            assertEquals(lastName.replace("-", "_"), record["replace(lastName, '-', '_')"]?.toString(), "Unexpected replace result")
+        } finally {
+            safeDelete("UserProfile", profile.id)
+            safeDelete("User", user.id)
+        }
+    }
 }
+
+private fun variance(attribute: String): String = "variance($attribute)"
+
+private fun percentile(attribute: String, p: Number): String = "percentile($attribute, $p)"


### PR DESCRIPTION
## Summary
- extend the Onyx Cloud aggregate integration test to cover count, median, variance, and percentile query functions
- add a dedicated integration test that exercises upper, lower, substring, and replace string query helpers

## Testing
- ./gradlew --console=plain :onyx-cloud-client:test *(fails: java.net.SocketException – external API is not reachable from the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d955fef88327860ca3ed6871ee44