### PR TITLE
Update delete API to use DeleteOptions

### DIFF
--- a/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/CascadeClientBuilder.kt
+++ b/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/CascadeClientBuilder.kt
@@ -1,5 +1,7 @@
 package com.onyx.cloud
 
+import com.onyx.cloud.api.DeleteOptions
+
 /**
  * Builder for cascading save or delete operations on the client.
  *
@@ -25,8 +27,8 @@ class CascadeClientBuilder(
      *
      * @param table Table name.
      * @param primaryKey Entity primary key.
-     * @return Success flag from the server.
+     * @return Result from the server.
      */
-    fun delete(table: String, primaryKey: String): Boolean =
-        client.delete(table, primaryKey, mapOf("relationships" to relationships))
+    fun delete(table: String, primaryKey: String): Any? =
+        client.delete(table, primaryKey, DeleteOptions(relationships = relationships))
 }


### PR DESCRIPTION
## Summary
- update `OnyxClient.delete` to take `DeleteOptions`, reuse them when deleting within a partition, and serialize delete options into query parameters
- ensure the cascade client builder routes delete calls through `DeleteOptions`

## Testing
- `./gradlew :onyx-cloud-client:test` *(fails: integration suite requires cloud access and multiple tests report failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cb805da8f0832796a5cd9d3fbf4e41