### PR TITLE
Add OnyxConfig fetch, partition, logging, and TTL support

### DIFF
--- a/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/impl/OnyxFacadeImpl.kt
+++ b/onyx-cloud-client/src/main/kotlin/com/onyx/cloud/impl/OnyxFacadeImpl.kt
@@ -27,7 +27,12 @@ object OnyxFacadeImpl : OnyxFacade {
             baseUrl = config?.baseUrl ?: "https://api.onyx.dev",
             databaseId = config?.databaseId ?: System.getenv("ONYX_DATABASE_ID"),
             apiKey = config?.apiKey ?: System.getenv("ONYX_API_KEY"),
-            apiSecret = config?.apiSecret ?: System.getenv("ONYX_API_SECRET")
+            apiSecret = config?.apiSecret ?: System.getenv("ONYX_API_SECRET"),
+            fetch = config?.fetch,
+            defaultPartition = config?.partition,
+            requestLoggingEnabled = config?.requestLoggingEnabled ?: false,
+            responseLoggingEnabled = config?.responseLoggingEnabled ?: false,
+            ttl = config?.ttl
         ) as IOnyxDatabase<Schema>
 
     override fun clearCacheConfig() {}

--- a/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/OnyxClientTest.kt
+++ b/onyx-cloud-client/src/test/kotlin/com/onyx/cloud/OnyxClientTest.kt
@@ -1,6 +1,10 @@
 package com.onyx.cloud
 
+import com.onyx.cloud.api.FetchInit
+import com.onyx.cloud.api.FetchResponse
 import com.onyx.cloud.impl.OnyxClient
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import kotlin.test.*
 
 /**
@@ -38,6 +42,114 @@ class OnyxClientTest {
         val qs = buildQuery(mapOf("limit" to 5, "active" to true))
         assertTrue(qs.contains("limit=5", ignoreCase = false))
         assertTrue(qs.contains("active=true", ignoreCase = false))
+    }
+
+    @Test
+    fun customFetchDelegatesRequests() {
+        var capturedUrl: String? = null
+        var capturedInit: FetchInit? = null
+        val customClient = OnyxClient(
+            baseUrl = "https://example.com",
+            databaseId = "db",
+            apiKey = "key",
+            apiSecret = "secret",
+            fetch = { url, init ->
+                capturedUrl = url
+                capturedInit = init
+                StubFetchResponse(bodyText = "true")
+            }
+        )
+
+        val success = customClient.delete("users", "42")
+
+        assertTrue(success)
+        assertEquals("https://example.com/data/db/users/42", capturedUrl)
+        assertEquals("DELETE", capturedInit?.method)
+        assertEquals("key", capturedInit?.headers?.get("x-onyx-key"))
+        assertEquals("secret", capturedInit?.headers?.get("x-onyx-secret"))
+    }
+
+    @Test
+    fun defaultPartitionAppliedWhenNotProvided() {
+        var capturedUrl: String? = null
+        val customClient = OnyxClient(
+            baseUrl = "https://example.com",
+            databaseId = "db",
+            apiKey = "key",
+            apiSecret = "secret",
+            defaultPartition = "tenant-a",
+            fetch = { url, _ ->
+                capturedUrl = url
+                StubFetchResponse(bodyText = "{\"id\":\"123\"}")
+            }
+        )
+
+        val entity: ExampleEntity? = customClient.findById(ExampleEntity::class, "123", null)
+
+        assertNotNull(entity)
+        assertEquals("123", entity.id)
+        assertTrue(capturedUrl?.contains("partition=tenant-a") == true)
+    }
+
+    @Test
+    fun requestAndResponseLoggingEmitsOutput() {
+        val originalOut = System.out
+        val captured = ByteArrayOutputStream()
+        System.setOut(PrintStream(captured))
+        try {
+            val loggingClient = OnyxClient(
+                baseUrl = "https://example.com",
+                databaseId = "db",
+                apiKey = "key",
+                apiSecret = "super-secret-value",
+                fetch = { _, _ -> StubFetchResponse(bodyText = "true") },
+                requestLoggingEnabled = true,
+                responseLoggingEnabled = true
+            )
+
+            assertTrue(loggingClient.deleteDocument("doc-1"))
+        } finally {
+            System.setOut(originalOut)
+        }
+
+        val output = captured.toString()
+        assertTrue(output.contains("OnyxClient Request"))
+        assertTrue(output.contains("OnyxClient Response"))
+        assertFalse(output.contains("super-secret-value"))
+        assertTrue(output.contains("****"))
+    }
+
+    @Test
+    fun ttlHeaderIsPropagated() {
+        var capturedInit: FetchInit? = null
+        val ttlClient = OnyxClient(
+            baseUrl = "https://example.com",
+            databaseId = "db",
+            apiKey = "key",
+            apiSecret = "secret",
+            ttl = 60_000,
+            fetch = { _, init ->
+                capturedInit = init
+                StubFetchResponse(bodyText = "true")
+            }
+        )
+
+        assertTrue(ttlClient.delete("users", "42"))
+        assertEquals("60000", capturedInit?.headers?.get("x-onyx-ttl"))
+    }
+
+    private data class ExampleEntity(val id: String)
+
+    private class StubFetchResponse(
+        override val status: Int = 200,
+        private val bodyText: String = "",
+        private val headerValues: Map<String, String> = emptyMap(),
+        override val statusText: String = "OK"
+    ) : FetchResponse {
+        override val ok: Boolean get() = status in 200..299
+        override fun header(name: String): String? = headerValues[name]
+        override fun text(): String = bodyText
+        override val body: Any? = bodyText
     }
 }
 


### PR DESCRIPTION
## Summary
- extend `OnyxClient` to accept the optional fetch implementation, default partition, request/response logging flags, and TTL header from `OnyxConfig`
- make `OnyxFacadeImpl` forward the new configuration properties when constructing the client
- add unit tests covering custom fetch delegation, default partition usage, request/response logging, and TTL propagation

## Testing
- `./gradlew :onyx-cloud-client:test --tests com.onyx.cloud.OnyxClientTest`
- `./gradlew :onyx-cloud-client:test` *(fails: SocketException from integration tests that require network services)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc675dda08327acec479d6c87b185