### PR TITLE
Add selectable Lucene score and wildcard selection support

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -2,7 +2,7 @@ import org.gradle.api.JavaVersion
 
 object Config {
     // Onyx Version
-    const val ONYX_VERSION = "3.9.5"
+    const val ONYX_VERSION = "3.9.6"
 
     // Took Versions
     const val JAVA_VERSION = 21

--- a/onyx-database-tests/src/test/kotlin/database/query/FullTextSearchTest.kt
+++ b/onyx-database-tests/src/test/kotlin/database/query/FullTextSearchTest.kt
@@ -8,6 +8,7 @@ import com.onyx.persistence.query.QueryCriteriaOperator
 import com.onyx.persistence.query.QueryPartitionMode
 import com.onyx.persistence.query.eq
 import com.onyx.persistence.query.from
+import com.onyx.persistence.query.like
 import com.onyx.persistence.query.search
 import com.onyx.persistence.query.searchAllTables
 import database.base.DatabaseBaseTest
@@ -19,6 +20,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import kotlin.reflect.KClass
 import kotlin.test.assertEquals
+import kotlin.test.assertContains
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -152,5 +154,49 @@ class FullTextSearchTest(override var factoryClass: KClass<*>) : DatabaseBaseTes
             .list<LuceneSearchEntity>()
 
         assertTrue(filtered.isEmpty())
+    }
+
+    @Test
+    fun testSelectScoreWithSearch() {
+        val searchEntity = LuceneSearchEntity().apply {
+            title = "Vector Database Guide"
+            body = "quick fox search score"
+            category = "docs"
+        }
+        manager.saveEntity<IManagedEntity>(searchEntity)
+
+        val results = manager.from<LuceneSearchEntity>()
+            .search("fox")
+            .select(Query.SCORE_SELECTION, Query.WILDCARD_SELECTION)
+            .list<Map<String, Any?>>()
+
+        assertTrue(results.isNotEmpty())
+        val first = results.first()
+        assertContains(first.keys, Query.SCORE_SELECTION)
+        assertNotNull(first[Query.SCORE_SELECTION] as Float?)
+        assertContains(first.keys, "id")
+        assertContains(first.keys, "title")
+        assertContains(first.keys, "body")
+        assertContains(first.keys, "category")
+    }
+
+    @Test
+    fun testSelectScoreWithLuceneLikeCriteria() {
+        val matchingEntity = LuceneSearchEntity().apply {
+            title = "alpha"
+            body = "body content"
+            category = "news"
+        }
+        manager.saveEntity<IManagedEntity>(matchingEntity)
+
+        val results = manager.from<LuceneSearchEntity>()
+            .select(Query.SCORE_SELECTION, "title")
+            .where("title" like "alpha")
+            .list<Map<String, Any?>>()
+
+        assertEquals(1, results.size)
+        val first = results.first()
+        assertContains(first.keys, Query.SCORE_SELECTION)
+        assertNotNull(first[Query.SCORE_SELECTION] as Float?)
     }
 }

--- a/onyx-database-tests/src/test/kotlin/database/query/SelectQueryTest.kt
+++ b/onyx-database-tests/src/test/kotlin/database/query/SelectQueryTest.kt
@@ -110,4 +110,19 @@ class SelectQueryTest(override var factoryClass: KClass<*>) : PrePopulatedDataba
         assertEquals("FIRST ONE", results[0]["id"], "Invalid query order")
         assertEquals("FIRST ONE4", results[1]["id"], "Invalid query order")
     }
+
+    @Test
+    fun testWildcardSelectReturnsAllEntityAttributes() {
+        val results = manager.from(AllAttributeForFetch::class)
+            .where("id" eq "FIRST ONE")
+            .select(Query.WILDCARD_SELECTION)
+            .list<Map<String, Any?>>()
+
+        assertEquals(1, results.size)
+        val result = results.first()
+        assertTrue(result.containsKey("id"))
+        assertTrue(result.containsKey("stringValue"))
+        assertTrue(result.containsKey("longValue"))
+        assertTrue(result.containsKey("intPrimitive"))
+    }
 }

--- a/onyx-database/src/main/kotlin/com/onyx/interactors/query/impl/DefaultQueryInteractor.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/interactors/query/impl/DefaultQueryInteractor.kt
@@ -38,6 +38,7 @@ class DefaultQueryInteractor(private var descriptor: EntityDescriptor, private v
      * been moved to CompareUtil
      */
     override fun <T> getReferencesForQuery(query: Query):QueryCollector<T> {
+        query.fullTextScores = null
         if (query.isTerminated) {
             val collector = QueryCollectorFactory.create<T>(Contexts.get(contextId)!!, descriptor, query)
             collector.finalizeResults()
@@ -77,6 +78,7 @@ class DefaultQueryInteractor(private var descriptor: EntityDescriptor, private v
         val maxCardinality = context.maxCardinality
         val limit = if (query.maxResults > 0) query.maxResults else maxCardinality - 1
         val matchingReferences = HashSet<Reference>()
+        val scores = HashMap<Reference, Float>()
         val minScore = criteriaQuery.minScore
 
         fun collectResults(partitionId: Long, interactor: FullTextRecordInteractor) {
@@ -86,7 +88,12 @@ class DefaultQueryInteractor(private var descriptor: EntityDescriptor, private v
                 if (matchingReferences.size > maxCardinality) {
                     throw MaxCardinalityExceededException(context.maxCardinality)
                 }
-                matchingReferences.add(Reference(partitionId, recordId))
+                val reference = Reference(partitionId, recordId)
+                matchingReferences.add(reference)
+                val previousScore = scores[reference]
+                if (previousScore == null || score > previousScore) {
+                    scores[reference] = score
+                }
             }
         }
 
@@ -99,6 +106,7 @@ class DefaultQueryInteractor(private var descriptor: EntityDescriptor, private v
                     collectResults(entry.index, interactor)
                 }
             }
+            query.fullTextScores = scores
             return matchingReferences
         }
 
@@ -121,6 +129,7 @@ class DefaultQueryInteractor(private var descriptor: EntityDescriptor, private v
             collectResults(partitionId, interactor)
         }
 
+        query.fullTextScores = scores
         return matchingReferences
     }
 

--- a/onyx-database/src/main/kotlin/com/onyx/interactors/query/impl/collectors/BaseQueryCollector.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/interactors/query/impl/collectors/BaseQueryCollector.kt
@@ -18,6 +18,7 @@ import com.onyx.persistence.context.SchemaContext
 import com.onyx.persistence.query.Query
 import java.util.Comparator
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.collections.LinkedHashSet
 
 /**
  * This class bores the responsibility of collecting results from a query.  It contains the base shared functionality
@@ -54,7 +55,31 @@ abstract class BaseQueryCollector<T>(
                 if(query.queryOrders?.isNotEmpty() == true) SortedList(EntityComparator(comparator)) as MutableCollection<T> else ArrayList()
 
     // Selection Query Attributes
-    protected val selections:List<QueryAttributeResource> by lazy { if(query.selections == null) emptyList() else QueryAttributeResource.create(query.selections!!.map { it }.toTypedArray(), descriptor, query, context) }
+    private val expandedSelections: List<String> by lazy {
+        val configuredSelections = query.selections ?: return@lazy emptyList()
+        val expanded = ArrayList<String>()
+        configuredSelections.forEach { selection ->
+            if (selection == Query.WILDCARD_SELECTION) {
+                expanded.addAll(descriptor.attributes.keys)
+            } else {
+                expanded.add(selection)
+            }
+        }
+        LinkedHashSet(expanded).toList()
+    }
+
+    private val concreteSelections: List<String> by lazy {
+        expandedSelections.filterNot { it == Query.SCORE_SELECTION }
+    }
+
+    // Selection Query Attributes
+    protected val selections:List<QueryAttributeResource> by lazy {
+        if (concreteSelections.isEmpty()) {
+            emptyList()
+        } else {
+            QueryAttributeResource.create(concreteSelections.toTypedArray(), descriptor, query, context)
+        }
+    }
 
     // Order by query attributes
     protected val orders:List<QueryAttributeResource> by lazy { if(query.queryOrders == null) emptyList() else QueryAttributeResource.create(query.queryOrders!!.map { it.attribute }.toTypedArray(), descriptor, query, context) }
@@ -72,7 +97,7 @@ abstract class BaseQueryCollector<T>(
     protected val allQueryAttributes:List<QueryAttributeResource> by lazy {
         val groupStrings = query.groupBy ?: emptyList()
         val orderByStrings = query.queryOrders?.map { it.attribute }?.toList() ?: ArrayList()
-        val selectionStrings = query.selections ?: emptyList()
+        val selectionStrings = concreteSelections
         val allStrings = groupStrings + orderByStrings + selectionStrings
         QueryAttributeResource.create(allStrings.toHashSet().toTypedArray(), descriptor, query, context)
     }
@@ -196,9 +221,9 @@ abstract class BaseQueryCollector<T>(
             }
             // Selection results.  Here we remove unselected fields that may have been part of the query orders or groups
             else if(query.selections?.size ?: 0 > 0
-                && query.selections!!.size != allQueryAttributes.size) {
+                && expandedSelections.size != allQueryAttributes.size) {
 
-                val itemsToRemove = allQueryAttributes.map { it.selection } - query.selections!!
+                val itemsToRemove = allQueryAttributes.map { it.selection } - expandedSelections
                 if(itemsToRemove.isNotEmpty()) {
                     results.forEach { record ->
                         itemsToRemove.forEach {
@@ -246,13 +271,18 @@ abstract class BaseQueryCollector<T>(
      * Get all selection data items and put them into a hash map.  This includes query orders, groups and selections.
      * It contains all data elements that can be used to aggregate a select query
      */
-    protected fun getSelectionRecord(entity: IManagedEntity) : HashMap<String, Any?> {
+    protected fun getSelectionRecord(entity: IManagedEntity, reference: Reference? = null) : HashMap<String, Any?> {
         val selectionResult = HashMap<String, Any?>()
         allQueryAttributes.forEach { selection ->
             if(selection.function == null)
                 selectionResult[selection.selection] = comparator.getAttribute(selection, entity, context)
             else
                 selectionResult[selection.selection] = selection.function.execute(comparator.getAttribute(selection, entity, context))
+        }
+
+        if (expandedSelections.contains(Query.SCORE_SELECTION)) {
+            val score = if (reference == null) null else query.fullTextScores?.get(reference)
+            selectionResult[Query.SCORE_SELECTION] = score
         }
 
         return selectionResult

--- a/onyx-database/src/main/kotlin/com/onyx/interactors/query/impl/collectors/BasicSelectionQueryCollector.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/interactors/query/impl/collectors/BasicSelectionQueryCollector.kt
@@ -34,7 +34,7 @@ open class BasicSelectionQueryCollector(
         if(entity == null)
             return
 
-        val selectionResult = getSelectionRecord(entity)
+        val selectionResult = getSelectionRecord(entity, reference)
 
         resultLock.perform {
             if(results.add(selectionResult))

--- a/onyx-database/src/main/kotlin/com/onyx/interactors/query/impl/collectors/GroupSelectionQueryCollector.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/interactors/query/impl/collectors/GroupSelectionQueryCollector.kt
@@ -27,7 +27,7 @@ class GroupSelectionQueryCollector(
             return
 
         val selections = getGroupResults(entity)
-        val selectionResult = getSelectionRecord(entity)
+        val selectionResult = getSelectionRecord(entity, reference)
 
         resultLock.perform {
             if (!groupedResults.contains(selections)) {

--- a/onyx-database/src/main/kotlin/com/onyx/persistence/query/LuceneCriteriaQuery.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/persistence/query/LuceneCriteriaQuery.kt
@@ -10,7 +10,7 @@ data class LuceneCriteriaQuery(
 
 internal fun buildLuceneCriteriaQuery(criteria: QueryCriteria, descriptor: EntityDescriptor): LuceneCriteriaQuery? {
     val result = buildCriteriaQuery(criteria, descriptor)
-    if (!result.supported || !result.hasFullText) return null
+    if (!result.supported) return null
     val queryText = result.queryText?.trim().orEmpty()
     if (queryText.isEmpty()) return null
     return LuceneCriteriaQuery(queryText, result.minScore)

--- a/onyx-database/src/main/kotlin/com/onyx/persistence/query/Query.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/persistence/query/Query.kt
@@ -2,6 +2,7 @@ package com.onyx.persistence.query
 
 import com.onyx.buffer.BufferStreamable
 import com.onyx.extension.getFunctionWithinSelection
+import com.onyx.interactors.record.data.Reference
 import com.onyx.persistence.function.QueryFunction
 import com.onyx.persistence.manager.PersistenceManager
 import kotlin.collections.ArrayList
@@ -40,6 +41,8 @@ import kotlin.collections.LinkedHashSet
 class Query : BufferStreamable {
     companion object {
         const val FULL_TEXT_ATTRIBUTE = "__full_text__"
+        const val SCORE_SELECTION = "__score__"
+        const val WILDCARD_SELECTION = "*"
     }
 
     /**
@@ -157,6 +160,12 @@ class Query : BufferStreamable {
 
     @Transient
     private var functions: List<QueryFunction>? = null
+
+    /**
+     * Full-text search scores keyed by record reference.
+     */
+    @Transient
+    var fullTextScores: Map<Reference, Float>? = null
 
     /**
      * Get the functions associated to the query selection

--- a/onyx-database/src/main/kotlin/com/onyx/persistence/query/QueryBuilder.kt
+++ b/onyx-database/src/main/kotlin/com/onyx/persistence/query/QueryBuilder.kt
@@ -229,6 +229,11 @@ class QueryBuilder(
         return this
     }
 
+    fun select(vararg properties: String): QueryBuilder {
+        this.query.selections = properties.toList()
+        return this
+    }
+
     fun and(criteria: QueryCriteria): QueryBuilder {
         this.query.criteria?.and(criteria)
         return this


### PR DESCRIPTION
### Motivation

- Provide a fluent way to project Lucene full-text similarity scores alongside selected fields so callers can compare vector closeness (e.g. `select("__score__", "*")`).
- Allow `select("*")` to return all entity attributes without the caller enumerating them.

### Description

- Added `Query.SCORE_SELECTION` (`"__score__``) and `Query.WILDCARD_SELECTION` (`"*"`) constants and a transient `Query.fullTextScores` map to hold per-reference Lucene scores. (`Query.kt`)
- Added `QueryBuilder.select(vararg properties: String)` so selections can be composed after `from()`/`search()` in fluent queries. (`QueryBuilder.kt`)
- Captured per-reference scores during Lucene-backed execution and stored the best score per `Reference` in the query so it can be projected later. (`DefaultQueryInteractor.kt`)
- Implemented wildcard expansion and score projection in the selection pipeline by expanding `*` to entity attributes, excluding `__score__` from attribute resolution, and injecting the stored score into selection maps when `__score__` is requested; collectors now pass the `Reference` into the projection. (`BaseQueryCollector.kt`, `BasicSelectionQueryCollector.kt`, `GroupSelectionQueryCollector.kt`)
- Relaxed Lucene criteria gating so supported Lucene criteria (e.g. `like`) can be executed through the Lucene path and thus expose scores. (`LuceneCriteriaQuery.kt`)
- Added unit tests that validate: `from().search(...).select("__score__","*")`, `from().select("__score__", ...).where("field" like "...")`, and `select("*")` wildcard behavior. (`FullTextSearchTest.kt`, `SelectQueryTest.kt`)

### Testing

- Ran targeted test suites with `./gradlew :onyx-database-tests:test --tests database.query.FullTextSearchTest --tests database.query.SelectQueryTest`, and the final run completed successfully (`BUILD SUCCESSFUL`).
- Tests exercise score projection for full-text search and Lucene-style `like` criteria and verify wildcard selection returns all entity attributes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9582660883278b5c1944557f7bf2)