### PR TITLE
Fix Lucene RecordInteractor shutdown to prevent corruption on factory reopen

### DIFF
--- a/onyx-database-tests/src/test/kotlin/database/query/FullTextSearchDataTypeTest.kt
+++ b/onyx-database-tests/src/test/kotlin/database/query/FullTextSearchDataTypeTest.kt
@@ -37,6 +37,35 @@ class FullTextSearchDataTypeTest(override var factoryClass: KClass<*>) : Databas
         fun persistenceManagersToTest(): Collection<KClass<*>> = listOf(EmbeddedPersistenceManagerFactory::class)
     }
 
+
+    @Test
+    fun testLuceneSearchDataSurvivesFactoryCloseAndReopenInSameProcess() {
+        val saved = manager.saveEntity<IManagedEntity>(LuceneSearchEntity().apply {
+            title = "reopen safety"
+            body = "lucene record interactor should not corrupt persisted data"
+            category = "regression"
+        }) as LuceneSearchEntity
+
+        // Close and re-open in the same JVM process.
+        factory.close()
+        initialize()
+
+        val byId = manager.from<LuceneSearchEntity>()
+            .where("id" eq saved.id)
+            .firstOrNull<LuceneSearchEntity>()
+
+        assertTrue(byId != null, "Entity should still be readable after reopen")
+        assertEquals("reopen safety", byId!!.title)
+        assertEquals("lucene record interactor should not corrupt persisted data", byId.body)
+        assertEquals("regression", byId.category)
+
+        val searchResults = manager.from<LuceneSearchEntity>()
+            .search("persisted data")
+            .list<LuceneSearchEntity>()
+
+        assertTrue(searchResults.any { it.id == saved.id }, "Re-opened factory should return the saved record in Lucene search")
+    }
+
     @Test
     fun testFullTextSearchWithDifferentDataTypes() {
         // Create entities with different data types

--- a/onyx-lucene-index/src/main/kotlin/com/onyx/lucene/interactors/record/impl/LuceneRecordInteractor.kt
+++ b/onyx-lucene-index/src/main/kotlin/com/onyx/lucene/interactors/record/impl/LuceneRecordInteractor.kt
@@ -466,19 +466,48 @@ open class LuceneRecordInteractor(
         private fun shutdownInstance(key: String) {
             val state = luceneStates.remove(key) ?: return
 
+            // Prevent the background commit worker from trying to commit while this key is shutting down.
+            IndexCommitScheduler.clearDirtyKey(key)
+
             runCatching {
                 state.reopenThread.close()
             }
 
-            try {
+            var closeError: Exception? = null
+
+            runCatching {
                 state.searcherManager.close()
-                state.indexWriter.commit()
-                state.indexWriter.close()
+            }.onFailure {
+                closeError = closeError ?: (it as? Exception ?: Exception(it))
+            }
+
+            runCatching {
+                if (state.indexWriter.isOpen) {
+                    state.indexWriter.commit()
+                }
+            }.onFailure {
+                closeError = closeError ?: (it as? Exception ?: Exception(it))
+            }
+
+            runCatching {
+                if (state.indexWriter.isOpen) {
+                    state.indexWriter.close()
+                }
+            }.onFailure {
+                closeError = closeError ?: (it as? Exception ?: Exception(it))
+            }
+
+            runCatching {
                 state.directory.close()
-                luceneDirectories.remove(key)
-            } catch (e: Exception) {
-                System.err.println("CRITICAL: Error closing Lucene Record Index '$key': ${e.message}")
-                e.printStackTrace()
+            }.onFailure {
+                closeError = closeError ?: (it as? Exception ?: Exception(it))
+            }
+
+            luceneDirectories.remove(key)
+
+            if (closeError != null) {
+                System.err.println("CRITICAL: Error closing Lucene Record Index '$key': ${closeError!!.message}")
+                closeError!!.printStackTrace()
             }
         }
 
@@ -552,6 +581,10 @@ open class LuceneRecordInteractor(
 
             fun markDirty(key: String) {
                 dirtyIndexKeys.add(key)
+            }
+
+            fun clearDirtyKey(key: String) {
+                dirtyIndexKeys.remove(key)
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Closing and re-opening a PersistenceManagerFactory in the same JVM could leave Lucene resources in an inconsistent state, allowing the background commit worker to race with shutdown and causing search/index corruption for Lucene-backed record interactors.
- The previous shutdown aborted remaining cleanup when one close step failed, which could leave writers/directories cached and cause failures on subsequent initialize/rehydrate.

### Description
- Hardened `LuceneRecordInteractor.shutdownInstance` to remove the key from the commit scheduler before teardown and to perform each close step (reopen thread, searcher manager, commit writer, close writer, close directory) in guarded blocks so failures in one step do not skip the rest of cleanup.
- Added `IndexCommitScheduler.clearDirtyKey(key)` and call it during shutdown to prevent the background commit worker from attempting commits while an index is being closed/reopened.
- Only commit/close the `IndexWriter` if it is open, always remove the cached directory reference, and surface aggregated close errors after cleanup.
- Added regression test `testLuceneSearchDataSurvivesFactoryCloseAndReopenInSameProcess` that closes and re-initializes the factory in-process and verifies both direct read and Lucene full-text search return the saved entity.

### Testing
- Ran `./gradlew :onyx-database-tests:test --tests database.query.FullTextSearchDataTypeTest.testLuceneSearchDataSurvivesFactoryCloseAndReopenInSameProcess` which reported no matching tests due to the parameterized test naming/filters (no tests found for given includes).
- Ran `./gradlew :onyx-database-tests:test --tests database.query.FullTextSearchDataTypeTest` and the test class executed successfully (BUILD SUCCESSFUL / tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e012a5c464832796195b36e79cc164)